### PR TITLE
reorder texts by indices

### DIFF
--- a/egs/librispeech/asr/simple_v1/decode.py
+++ b/egs/librispeech/asr/simple_v1/decode.py
@@ -40,6 +40,7 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
         indices = torch.argsort(supervision_segments[:, 2], descending=True)
         supervision_segments = supervision_segments[indices]
         texts = supervisions['text']
+        texts = [texts[idx] for idx in indices]
         assert feature.ndim == 3
 
         feature = feature.to(device)

--- a/egs/librispeech/asr/simple_v1/train.py
+++ b/egs/librispeech/asr/simple_v1/train.py
@@ -76,6 +76,7 @@ def get_objf(batch: Dict,
     supervision_segments = supervision_segments[indices]
 
     texts = supervisions['text']
+    texts = [texts[idx] for idx in indices]
     assert feature.ndim == 3
     # print(supervision_segments[:, 1] + supervision_segments[:, 2])
 


### PR DESCRIPTION
It seems there is a small bug in train.py and decode.py. In train.py：

 supervision_segments = supervision_segments[indices]

    texts = supervisions['text']
    assert feature.ndim == 3
    # print(supervision_segments[:, 1] + supervision_segments[:, 2])
The "texts" is not reorder by indices, while supervision_segments have been reorder. And in decode.py there is same bug.
I reorder "texts" by indices and retrain the model, the WER reduce to 87.01% after 5 epoches.