### PR TITLE
Use kaldi's arpa2fst to convert LM to FST.

### DIFF
--- a/egs/librispeech/asr/simple_v1/ctc_decode.py
+++ b/egs/librispeech/asr/simple_v1/ctc_decode.py
@@ -148,7 +148,7 @@ def main():
             L = k2.Fsa.from_openfst(f.read(), acceptor=False)
         print("Loading G.fsa.txt")
         with open(lang_dir / 'G.fsa.txt') as f:
-            G = k2.Fsa.from_openfst(f.read(), acceptor=True)
+            G = k2.Fsa.from_openfst(f.read(), acceptor=False)
         first_phone_disambig_id = find_first_disambig_symbol(phone_symbol_table)
         first_word_disambig_id = find_first_disambig_symbol(symbol_table)
         LG = compile_LG(L=L,

--- a/egs/librispeech/asr/simple_v1/mmi_bigram_decode.py
+++ b/egs/librispeech/asr/simple_v1/mmi_bigram_decode.py
@@ -236,7 +236,7 @@ def main():
             L = k2.Fsa.from_openfst(f.read(), acceptor=False)
         logging.debug("Loading G.fsa.txt")
         with open(lang_dir / 'G.fsa.txt') as f:
-            G = k2.Fsa.from_openfst(f.read(), acceptor=True)
+            G = k2.Fsa.from_openfst(f.read(), acceptor=False)
         first_phone_disambig_id = find_first_disambig_symbol(phone_symbol_table)
         first_word_disambig_id = find_first_disambig_symbol(symbol_table)
         LG = compile_LG(L=L,

--- a/egs/librispeech/asr/simple_v1/run.sh
+++ b/egs/librispeech/asr/simple_v1/run.sh
@@ -10,7 +10,7 @@ set -eou pipefail
 stage=1
 
 if [ $stage -le 1 ]; then
-  local/download_lm.sh "openslr.magicdatatech.com/resources/11" data/local/lm
+  local/download_lm.sh "openslr.org/resources/11" data/local/lm
 fi
 
 if [ $stage -le 2 ]; then
@@ -31,8 +31,11 @@ fi
 
 if [ $stage -le 4 ]; then
   # Build G
-  local/arpa2fst.py data/local/lm/lm_tgmed.arpa |
-    local/sym2int.pl -f 3 data/lang_nosp/words.txt >data/lang_nosp/G.fsa.txt
+  python3 -m kaldilm \
+    --read-symbol-table="data/lang_nosp/words.txt" \
+    --disambig-symbol='#0' \
+    --max-order=3 \
+    data/local/lm/lm_tgmed.arpa >data/lang_nosp/G.fsa.txt
 
   echo "To load G:"
   echo "    Gfsa = k2.Fsa.from_openfst(<string of data/lang_nosp/G.fsa.txt>, acceptor=True)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 k2
 kaldialign
+kaldilm
 lhotse@git+https://github.com/lhotse-speech/lhotse
 tensorboard
 torch>=1.6.0

--- a/snowfall/decoding/graph.py
+++ b/snowfall/decoding/graph.py
@@ -30,13 +30,13 @@ def compile_LG(L: Fsa, G: Fsa, ctc_topo: Fsa, labels_disambig_id_start: int,
             words vocabulary.
     :return:
     """
-    L_inv = k2.arc_sort(L.invert_())
+    L = k2.arc_sort(L)
     G = k2.arc_sort(G)
     logging.debug("Intersecting L and G")
-    LG = k2.intersect(L_inv, G)
+    LG = k2.compose(L, G)
     logging.debug(f'LG shape = {LG.shape}')
     logging.debug("Connecting L*G")
-    LG = k2.connect(LG).invert_()
+    LG = k2.connect(LG)
     logging.debug(f'LG shape = {LG.shape}')
     logging.debug("Determinizing L*G")
     LG = k2.determinize(LG)


### PR DESCRIPTION
I have disabled `RemoveRedundantStates();` in kaldi's arpa2fst as it seems that `compose(L, G)` is not going to terminate
when it is enabled.

For mmi_bigram_decode.py, the WER was 10.35%. With kaldilm, it is 10.16%.

See https://github.com/csukuangfj/kaldilm/blob/master/kaldilm/csrc/arpa_lm_compiler.cc#L381
```cpp
void ArpaLmCompiler::ReadComplete() {
  fst_.SetInputSymbols(Symbols());
  fst_.SetOutputSymbols(Symbols());
  // RemoveRedundantStates();
  Check();
}
```

To install `kaldilm`, use

```
pip install kaldilm
```

Its usage is
```
$ python3 -m kaldilm --help
usage: Python wrapper of kaldi's arpa2fst [-h] [--bos-symbol BOS_SYMBOL] [--disambig-symbol DISAMBIG_SYMBOL]
                                          [--eos-symbol EOS_SYMBOL] [--ilabel-sort ILABEL_SORT] [--keep-symbols KEEP_SYMBOLS]
                                          [--max-arpa-warnings MAX_ARPA_WARNINGS] [--read-symbol-table READ_SYMBOL_TABLE]
                                          [--write-symbol-table WRITE_SYMBOL_TABLE] [--max-order MAX_ORDER]
                                          input_arpa [output_fst]

positional arguments:
  input_arpa            input arpa filename
  output_fst            Output fst filename. If empty, no output file is created.

optional arguments:
  -h, --help            show this help message and exit
  --bos-symbol BOS_SYMBOL
                        Beginning of sentence symbol (default = "<s>")
  --disambig-symbol DISAMBIG_SYMBOL
                        Disambiguator. If provided (e.g., #0), used on input side of backoff links, and <s> and </s> are replaced
                        with epsilons (default = "")
  --eos-symbol EOS_SYMBOL
                        End of sentence symbol (default = "</s>")
  --ilabel-sort ILABEL_SORT
                        Ilabel-sort the output FST (default = true)
  --keep-symbols KEEP_SYMBOLS
                        Store symbol table with FST. Symbols always saved to FST if symboltables are neither read or written
                        (otherwise symbols would be lost entirely) (default = false)
  --max-arpa-warnings MAX_ARPA_WARNINGS
                        Maximum warnings to report on ARPA parsing, 0 to disable, -1 to show all (default = 30)
  --read-symbol-table READ_SYMBOL_TABLE
                        Use existing symbol table (default = "")
  --write-symbol-table WRITE_SYMBOL_TABLE
                        (Write generated symbol table to a file (default = "")
  --max-order MAX_ORDER
                        Maximum order (inclusive) in the arpa file is used to generate the final FST. If it is -1, all ngram data in
                        the file are used.If it is 1, only unigram data are used.If it is 2, only ngram data up to bigram are
                        used.Default is -1.
```

which prints essentially the same help message as kaldi's arpa2fst.

It supports one extra argument `--max-order`. See the help information about its meaning.