### PR TITLE
[WIP] MMI graph compilation inside dataloader

### DIFF
--- a/snowfall/training/mmi_graph.py
+++ b/snowfall/training/mmi_graph.py
@@ -47,7 +47,8 @@ class MmiTrainingGraphCompiler(object):
                  L_inv: k2.Fsa,
                  phones: k2.SymbolTable,
                  words: k2.SymbolTable,
-                 oov: str = '<UNK>'):
+                 oov: str = '<UNK>',
+                 use_cache: bool = True):
         '''
         Args:
           L_inv:
@@ -79,6 +80,9 @@ class MmiTrainingGraphCompiler(object):
         assert ctc_topo.requires_grad is False
 
         self.ctc_topo_inv = k2.arc_sort(ctc_topo.invert_())
+
+        if use_cache:
+            self.compile_one_and_cache = lru_cache(maxsize=100000)(self.compile_one_and_cache)
 
     def compile(self, texts: Iterable[str],
                 P: k2.Fsa) -> Tuple[k2.Fsa, k2.Fsa]:
@@ -116,7 +120,6 @@ class MmiTrainingGraphCompiler(object):
 
         return num, den
 
-    @lru_cache(maxsize=100000)
     def compile_one_and_cache(self, text: str) -> k2.Fsa:
         '''Convert transcript to an Fsa with the help of lexicon
         and word symbol table.


### PR DESCRIPTION
This code works only with DataLoader num_workers=0, and when we comment out the assertion `assert num.requires_grad == is_training`.

As to `num_workers`, when we set it to 1 or greater, it will spawn subprocesses and require the objects passed between to be pickle-able. I think that Fsa/FsaVec has no pickling support at the moment which is why the subprocess crashes (it's actually frustrating because you can't easily attach to it with GDB).

As to `num.requires_grad`, I am not sure if it needs to be True - the training seems to work fine when it's False? It's not like we're updating the numerator FSA parameters, since it gets deleted soon after the batch is processed anyway. In any case, the line where I set it to True actually does nothing - I'll get rid of it before we merge this (eventually).

