### PR TITLE
[WIP] 2-state HMM topo as an alternative to CTC topo

### DIFF
--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
@@ -29,9 +29,10 @@ from snowfall.common import load_checkpoint, save_checkpoint
 from snowfall.common import save_training_info
 from snowfall.common import setup_logger
 from snowfall.models import AcousticModel
-from snowfall.models.transformer import Noam, Transformer
 from snowfall.models.conformer import Conformer
+from snowfall.models.transformer import Noam, Transformer
 from snowfall.training.diagnostics import measure_gradient_norms, optim_step_and_measure_param_change
+from snowfall.training.hmm_topo import build_hmm_topo_2state
 from snowfall.training.mmi_graph import MmiTrainingGraphCompiler
 from snowfall.training.mmi_graph import create_bigram_phone_lm
 from snowfall.training.mmi_graph import get_phone_symbols
@@ -472,6 +473,7 @@ def main():
         phones=phone_symbol_table,
         words=word_symbol_table,
         device=device,
+        topo_builder_fn=build_hmm_topo_2state
     )
     phone_ids = get_phone_symbols(phone_symbol_table)
     P = create_bigram_phone_lm(phone_ids)
@@ -550,7 +552,7 @@ def main():
             num_features=40,
             nhead=args.nhead,
             d_model=args.attention_dim,
-            num_classes=len(phone_ids) + 1,  # +1 for the blank symbol
+            num_classes=2 * (len(phone_ids) + 1),  # +1 for the blank symbol
             subsampling_factor=4,
             num_decoder_layers=num_decoder_layers)
     else:
@@ -558,7 +560,7 @@ def main():
             num_features=40,
             nhead=args.nhead,
             d_model=args.attention_dim,
-            num_classes=len(phone_ids) + 1,  # +1 for the blank symbol
+            num_classes=2 * (len(phone_ids) + 1),  # +1 for the blank symbol
             subsampling_factor=4,
             num_decoder_layers=num_decoder_layers)
             

--- a/snowfall/training/hmm_topo.py
+++ b/snowfall/training/hmm_topo.py
@@ -1,0 +1,48 @@
+import k2
+from typing import List
+
+
+def build_hmm_topo_2state(tokens: List[int]) -> k2.Fsa:
+    """
+    Build a 2-state HMM topology used in Kaldi's chain models.
+    The first HMM state is entered only once for each token instance,
+    and the second HMM state is self-looped and optional.
+
+    Args:
+        tokens:
+            A list of token int IDs, e.g., phones, characters, etc.
+            The IDs for the first HMM state will be the same as token IDs;
+            The IDs for the second HMM state are: ``token_id + len(tokens)``
+    Returns:
+        An FST that converts a sequence of HMM state IDs to a sequence of token IDs.
+    """
+    followup_tokens = range(len(tokens), len(tokens) * 2)
+    num_states = len(tokens) + 2  # + start state, + final state
+    arcs = []
+
+    # Start state -> token state
+    for i in range(0, len(tokens)):
+        arcs += [f'0 {i + 1} {tokens[i]} {tokens[i]} 0.0']
+
+    # Token state self loops
+    for i in range(0, len(tokens)):
+        arcs += [f'{i + 1} {i + 1} {followup_tokens[i]} 0 0.0']
+
+    # Cross-token transitions
+    for i in range(0, len(tokens)):
+        for j in range(0, len(tokens)):
+            if i != j:
+                arcs += [f'{i + 1} {j + 1} {tokens[i]} {tokens[i]} 0.0']
+
+    # Token state -> superfinal state
+    for i in range(0, len(tokens)):
+        arcs += [f'{i + 1} {num_states - 1} -1 -1 0.0']
+
+    # Final state
+    arcs += [f'{num_states - 1}']
+
+    # Build the FST
+    arcs = '\n'.join(sorted(arcs))
+    ans = k2.Fsa.from_str(arcs)
+    ans = k2.arc_sort(ans)
+    return ans


### PR DESCRIPTION
I'm trying to build a topology where the "blank" is phone-specific instead of shared between phones (I believe that corresponds to Kaldi's chain topology).

I added a function `build_hmm_topo_2state` which seems to work OK for low numbers of tokens, but crashes at inputs that have more than 8 elements. Except for this function, this PR is not otherwise ready for review.

The first problematic input is `[0, 1, 2, 3, 4, 5, 6, 7, 8]`, everything smaller than that works. This is how the FSA looks for 1, 2, and 3 element lists:

![image](https://user-images.githubusercontent.com/15930688/110998984-ac37f180-834d-11eb-801c-0cf10bdcb31d.png)

It also seems to work when `0` is in the input IDs although I'm not sure if K2 has any hard-coded assumptions about symbols with ID `0` (I think OpenFST did).

For the problematic inputs, the program crashes with message:
```
[F] /exp/pzelasko/k2/k2/csrc/fsa_utils.cu:k2::Fsa k2::K2TransducerFromStream(std::istringstream&, k2::Array1<int>*):203 Check failed: finished == false (1 vs. 0)


[ Stack-Trace: ]
/exp/pzelasko/k2/build/lib/libk2_log.so(k2::internal::GetStackTrace()+0x34) [0x2aab587d98e4]
/exp/pzelasko/k2/build/lib/libk2context.so(k2::internal::Logger::~Logger()+0x28) [0x2aab53cc5fe8]
/exp/pzelasko/k2/build/lib/libk2context.so(+0xf6b37) [0x2aab53d4fb37]
/exp/pzelasko/k2/build/lib/libk2context.so(k2::FsaFromString(std::string const&, bool, k2::Array1<int>*)+0x416) [0x2aab53d50b06]
/home/hltcoe/pzelasko/miniconda3/envs/k2env/lib/python3.7/site-packages/_k2.cpython-37m-x86_64-linux-gnu.so(+0x3b836) [0x2aab50447836]
/home/hltcoe/pzelasko/miniconda3/envs/k2env/lib/python3.7/site-packages/_k2.cpython-37m-x86_64-linux-gnu.so(+0x1a6d3) [0x2aab504266d3]
/home/hltcoe/pzelasko/miniconda3/envs/k2env/bin/python(_PyMethodDef_RawFastCallKeywords+0x274) [0x5555556b9914]
```