### PR TITLE
[WIP] Training with on-the-fly feature extraction

### DIFF
--- a/egs/aishell/asr/simple_v1/ctc_decode.py
+++ b/egs/aishell/asr/simple_v1/ctc_decode.py
@@ -32,7 +32,7 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)
     for batch_idx, batch in enumerate(dataloader):
-        feature = batch['features']
+        feature = batch['inputs']
         supervisions = batch['supervisions']
         supervision_segments = torch.stack(
             (supervisions['sequence_idx'],

--- a/egs/aishell/asr/simple_v1/ctc_train.py
+++ b/egs/aishell/asr/simple_v1/ctc_train.py
@@ -69,7 +69,7 @@ def get_objf(batch: Dict,
              graph_compiler: CtcTrainingGraphCompiler,
              training: bool,
              optimizer: Optional[torch.optim.Optimizer] = None):
-    feature = batch['features']
+    feature = batch['inputs']
     supervisions = batch['supervisions']
     supervision_segments = torch.stack(
         (supervisions['sequence_idx'],

--- a/egs/aishell/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/aishell/asr/simple_v1/mmi_att_transformer_decode.py
@@ -37,7 +37,7 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)
     for batch_idx, batch in enumerate(dataloader):
-        feature = batch['features']
+        feature = batch['inputs']
         supervisions = batch['supervisions']
         supervision_segments = torch.stack(
             (supervisions['sequence_idx'],

--- a/egs/aishell/asr/simple_v1/mmi_att_transformer_train.py
+++ b/egs/aishell/asr/simple_v1/mmi_att_transformer_train.py
@@ -83,7 +83,7 @@ def get_objf(batch: Dict,
              global_batch_idx_train: Optional[int] = None,
              optimizer: Optional[torch.optim.Optimizer] = None):
 
-    feature = batch['features']
+    feature = batch['inputs']
     supervisions = batch['supervisions']
     supervision_segments = torch.stack(
         (supervisions['sequence_idx'],

--- a/egs/aishell/asr/simple_v1/mmi_bigram_decode.py
+++ b/egs/aishell/asr/simple_v1/mmi_bigram_decode.py
@@ -34,7 +34,7 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)
     for batch_idx, batch in enumerate(dataloader):
-        feature = batch['features']
+        feature = batch['inputs']
         supervisions = batch['supervisions']
         supervision_segments = torch.stack(
             (supervisions['sequence_idx'],

--- a/egs/aishell/asr/simple_v1/mmi_bigram_train.py
+++ b/egs/aishell/asr/simple_v1/mmi_bigram_train.py
@@ -77,7 +77,7 @@ def get_objf(batch: Dict,
              tb_writer: Optional[SummaryWriter] = None,
              global_batch_idx_train: Optional[int] = None,
              optimizer: Optional[torch.optim.Optimizer] = None):
-    feature = batch['features']
+    feature = batch['inputs']
     supervisions = batch['supervisions']
     supervision_segments = torch.stack(
         (supervisions['sequence_idx'],

--- a/egs/librispeech/asr/simple_v1/ctc_att_transformer_decode.py
+++ b/egs/librispeech/asr/simple_v1/ctc_att_transformer_decode.py
@@ -35,7 +35,7 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)
     for batch_idx, batch in enumerate(dataloader):
-        feature = batch['features']
+        feature = batch['inputs']
         supervisions = batch['supervisions']
         supervision_segments = torch.stack(
             (supervisions['sequence_idx'],

--- a/egs/librispeech/asr/simple_v1/ctc_att_transformer_train.py
+++ b/egs/librispeech/asr/simple_v1/ctc_att_transformer_train.py
@@ -73,7 +73,7 @@ def get_objf(batch: Dict,
              accum_grad: int = 1,
              att_rate: float = 0.0,
              optimizer: Optional[torch.optim.Optimizer] = None):
-    feature = batch['features']
+    feature = batch['inputs']
     supervisions = batch['supervisions']
     supervision_segments = torch.stack(
         (supervisions['sequence_idx'],

--- a/egs/librispeech/asr/simple_v1/ctc_decode.py
+++ b/egs/librispeech/asr/simple_v1/ctc_decode.py
@@ -32,7 +32,7 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)
     for batch_idx, batch in enumerate(dataloader):
-        feature = batch['features']
+        feature = batch['inputs']
         supervisions = batch['supervisions']
         supervision_segments = torch.stack(
             (supervisions['sequence_idx'],

--- a/egs/librispeech/asr/simple_v1/ctc_train.py
+++ b/egs/librispeech/asr/simple_v1/ctc_train.py
@@ -69,7 +69,7 @@ def get_objf(batch: Dict,
              graph_compiler: CtcTrainingGraphCompiler,
              training: bool,
              optimizer: Optional[torch.optim.Optimizer] = None):
-    feature = batch['features']
+    feature = batch['inputs']
     supervisions = batch['supervisions']
     supervision_segments = torch.stack(
         (supervisions['sequence_idx'],

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
@@ -38,7 +38,7 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)
     for batch_idx, batch in enumerate(dataloader):
-        feature = batch['features']
+        feature = batch['inputs']
         supervisions = batch['supervisions']
         supervision_segments = torch.stack(
             (supervisions['sequence_idx'],
@@ -206,7 +206,7 @@ def main():
     avg = args.avg
     att_rate = args.att_rate
 
-    exp_dir = Path('exp-' + model_type + '-noam-mmi-att-musan')
+    exp_dir = Path('exp-' + model_type + '-noam-mmi-att-musan-otf')
     setup_logger('{}/log/log-decode'.format(exp_dir), log_level='debug')
 
     # load L, G, symbol_table

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
@@ -169,10 +169,10 @@ def get_parser():
         default=10,
         help="Decoding epoch.")
     parser.add_argument(
-        '--max-frames',
+        '--max-duration',
         type=int,
-        default=100000,
-        help="Maximum number of feature frames in a single batch.")
+        default=1000.0,
+        help="Maximum pooled recordings duration (seconds) in a single batch.")
     parser.add_argument(
         '--avg',
         type=int,
@@ -202,11 +202,11 @@ def main():
 
     model_type = args.model_type
     epoch = args.epoch
-    max_frames = args.max_frames
+    max_duration = args.max_duration
     avg = args.avg
     att_rate = args.att_rate
 
-    exp_dir = Path('exp-' + model_type + '-noam-mmi-att-musan-otf')
+    exp_dir = Path('exp-' + model_type + '-noam-mmi-att-musan')
     setup_logger('{}/log/log-decode'.format(exp_dir), log_level='debug')
 
     # load L, G, symbol_table
@@ -294,7 +294,7 @@ def main():
 
     logging.debug("About to create test dataset")
     test = K2SpeechRecognitionDataset(cuts_test)
-    sampler = SingleCutSampler(cuts_test, max_frames=max_frames)
+    sampler = SingleCutSampler(cuts_test, max_duration=max_duration)
     logging.debug("About to create test dataloader")
     test_dl = torch.utils.data.DataLoader(test, batch_size=None, sampler=sampler, num_workers=1)
 

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
@@ -363,15 +363,10 @@ def get_parser():
         default=0,
         help="Number of start epoch.")
     parser.add_argument(
-        '--max-frames',
-        type=int,
-        default=50000,
-        help="Maximum number of feature frames in a single batch.")
-    parser.add_argument(
         '--max-duration',
         type=int,
         default=500.0,
-        help="Maximum pooled recordings duration in a single batch.")
+        help="Maximum pooled recordings duration (seconds) in a single batch.")
     parser.add_argument(
         '--warm-step',
         type=int,
@@ -462,7 +457,7 @@ def main():
 
     fix_random_seed(42)
 
-    exp_dir = Path('exp-' + model_type + '-noam-mmi-att-musan-otf')
+    exp_dir = Path('exp-' + model_type + '-noam-mmi-att-musan')
     setup_logger('{}/log/log-train'.format(exp_dir))
     tb_writer = SummaryWriter(log_dir=f'{exp_dir}/tensorboard')
 
@@ -538,7 +533,6 @@ def main():
         train_sampler = BucketingSampler(
             cuts_train,
             max_duration=max_duration,
-            # max_frames=max_frames,
             shuffle=True,
             num_buckets=args.num_buckets
         )
@@ -547,7 +541,6 @@ def main():
         train_sampler = SingleCutSampler(
             cuts_train,
             max_duration=max_duration,
-            # max_frames=max_frames,
             shuffle=True,
         )
     logging.info("About to create train dataloader")
@@ -570,7 +563,6 @@ def main():
     valid_sampler = SingleCutSampler(
         cuts_dev,
         max_duration=max_duration,
-        # max_frames=max_frames
     )
     logging.info("About to create dev dataloader")
     valid_dl = torch.utils.data.DataLoader(

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
@@ -519,11 +519,12 @@ def main():
     train = K2SpeechRecognitionDataset(cuts_train, cut_transforms=transforms)
 
     if args.on_the_fly_feats:
-        # Add on-the-fly speed perturbation; since originally it would have increased epoch
-        # size by 3, we will apply prob 2/3 and use 3x more epochs.
-        # Speed perturbation probably should come first before concatenation,
-        # but in principle the transforms order doesn't have to be strict (e.g. could be randomized)
-        transforms = [PerturbSpeed(factors=[0.9, 1.1], p=2 / 3)] + transforms
+        # NOTE: the PerturbSpeed transform should be added only if we remove it from data prep stage.
+        # # Add on-the-fly speed perturbation; since originally it would have increased epoch
+        # # size by 3, we will apply prob 2/3 and use 3x more epochs.
+        # # Speed perturbation probably should come first before concatenation,
+        # # but in principle the transforms order doesn't have to be strict (e.g. could be randomized)
+        # transforms = [PerturbSpeed(factors=[0.9, 1.1], p=2 / 3)] + transforms
         # Drop feats to be on the safe side.
         cuts_train = cuts_train.drop_features()
         train = K2SpeechRecognitionDataset(

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
@@ -85,7 +85,7 @@ def get_objf(batch: Dict,
              tb_writer: Optional[SummaryWriter] = None,
              global_batch_idx_train: Optional[int] = None,
              optimizer: Optional[torch.optim.Optimizer] = None):
-    feature = batch['features']
+    feature = batch['inputs']
     supervisions = batch['supervisions']
     supervision_segments = torch.stack(
         (supervisions['sequence_idx'],
@@ -198,7 +198,8 @@ def get_validation_objf(dataloader: torch.utils.data.DataLoader,
 
     model.eval()
 
-    for batch_idx, batch in enumerate(dataloader):
+    from torchaudio.datasets.utils import bg_iterator
+    for batch_idx, batch in enumerate(bg_iterator(dataloader, 2)):
         objf, frames, all_frames = get_objf(
             batch=batch,
             model=model,

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
@@ -367,6 +367,11 @@ def get_parser():
         default=50000,
         help="Maximum number of feature frames in a single batch.")
     parser.add_argument(
+        '--max-duration',
+        type=int,
+        default=500.0,
+        help="Maximum pooled recordings duration in a single batch.")
+    parser.add_argument(
         '--warm-step',
         type=int,
         default=5000,
@@ -449,6 +454,7 @@ def main():
     start_epoch = args.start_epoch
     num_epochs = args.num_epochs
     max_frames = args.max_frames
+    max_duration = args.max_duration
     accum_grad = args.accum_grad
     den_scale = args.den_scale
     att_rate = args.att_rate
@@ -529,7 +535,8 @@ def main():
         logging.info('Using BucketingSampler.')
         train_sampler = BucketingSampler(
             cuts_train,
-            max_frames=max_frames,
+            max_duration=max_duration,
+            # max_frames=max_frames,
             shuffle=True,
             num_buckets=args.num_buckets
         )
@@ -537,7 +544,8 @@ def main():
         logging.info('Using SingleCutSampler.')
         train_sampler = SingleCutSampler(
             cuts_train,
-            max_frames=max_frames,
+            max_duration=max_duration,
+            # max_frames=max_frames,
             shuffle=True,
         )
     logging.info("About to create train dataloader")
@@ -557,7 +565,11 @@ def main():
         )
     else:
         validate = K2SpeechRecognitionDataset(cuts_dev)
-    valid_sampler = SingleCutSampler(cuts_dev, max_frames=max_frames)
+    valid_sampler = SingleCutSampler(
+        cuts_dev,
+        max_duration=max_duration,
+        # max_frames=max_frames
+    )
     logging.info("About to create dev dataloader")
     valid_dl = torch.utils.data.DataLoader(
         validate,

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
@@ -449,7 +449,6 @@ def main():
     model_type = args.model_type
     start_epoch = args.start_epoch
     num_epochs = args.num_epochs
-    max_frames = args.max_frames
     max_duration = args.max_duration
     accum_grad = args.accum_grad
     den_scale = args.den_scale

--- a/egs/librispeech/asr/simple_v1/mmi_bigram_decode.py
+++ b/egs/librispeech/asr/simple_v1/mmi_bigram_decode.py
@@ -34,7 +34,7 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)
     for batch_idx, batch in enumerate(dataloader):
-        feature = batch['features']
+        feature = batch['inputs']
         supervisions = batch['supervisions']
         supervision_segments = torch.stack(
             (supervisions['sequence_idx'],

--- a/egs/librispeech/asr/simple_v1/mmi_bigram_train.py
+++ b/egs/librispeech/asr/simple_v1/mmi_bigram_train.py
@@ -82,7 +82,7 @@ def get_objf(batch: Dict,
              tb_writer: Optional[SummaryWriter] = None,
              global_batch_idx_train: Optional[int] = None,
              optimizer: Optional[torch.optim.Optimizer] = None):
-    feature = batch['features']
+    feature = batch['inputs']
     supervisions = batch['supervisions']
     subsampling_factor = model.module.subsampling_factor if isinstance(model, DDP) else model.subsampling_factor
     supervision_segments = torch.stack(

--- a/egs/librispeech/asr/simple_v1/mmi_mbr_decode.py
+++ b/egs/librispeech/asr/simple_v1/mmi_mbr_decode.py
@@ -34,7 +34,7 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)
     for batch_idx, batch in enumerate(dataloader):
-        feature = batch['features']
+        feature = batch['inputs']
         supervisions = batch['supervisions']
         supervision_segments = torch.stack(
             (supervisions['sequence_idx'],

--- a/egs/librispeech/asr/simple_v1/mmi_mbr_train.py
+++ b/egs/librispeech/asr/simple_v1/mmi_mbr_train.py
@@ -78,7 +78,7 @@ def get_loss(batch: Dict,
              is_training: bool,
              optimizer: Optional[torch.optim.Optimizer] = None):
     assert P.device == device
-    feature = batch['features']
+    feature = batch['inputs']
     supervisions = batch['supervisions']
     supervision_segments = torch.stack(
         (supervisions['sequence_idx'],


### PR DESCRIPTION
This is how on-the-fly feature extraction would look like. The main differences are that:
- the cuts (speech and noise) are mixed and padded in the time domain, not fbank domain
- there is no lilcom compression
- [not in this PR yet] speed perturbation could be applied stochastically; instead of creating 3x larger epochs, we can have 3x more epochs and apply perturbation with a given probability

I think I will revert `'inputs'` key back to `'features'` in batches, and replace `max_frames` everywhere with `max_duration` (the relationship is simple - multiply duration by 100 and you have the num_frames). I'll also add option to `prepare.py` not to extract features.

Preliminary results are actually worse for on-the-fly variant, but I haven't figured out why yet. I'll have to inspect the batches more carefully to understand that.

**Baseline WER (pre-computed features + feat-domain mixing):**
```2021-03-12 22:46:33,175 INFO [mmi_att_transformer_decode.py:330] %WER 6.82% [3587 / 52576, 512 ins, 284 del, 2791 sub ]```

**On-the-fly WER:**
```2021-03-16 09:27:06,059 INFO [mmi_att_transformer_decode.py:330] %WER 7.01% [3684 / 52576, 512 ins, 284 del, 2888 sub ]```