### PR TITLE
WIP: hugginface tokenizer and Neural LM training pipeline.

### DIFF
--- a/egs/librispeech/asr/nnlm/local/data.py
+++ b/egs/librispeech/asr/nnlm/local/data.py
@@ -1,0 +1,54 @@
+import os
+from io import open
+import torch
+
+
+class Dictionary(object):
+
+    def __init__(self):
+        self.word2idx = {}
+        self.idx2word = []
+        self.idx2word.append('<PAD>')
+        self.word2idx['<PAD>'] = 0
+
+    def add_word(self, word):
+        if word not in self.word2idx:
+            self.idx2word.append(word)
+            self.word2idx[word] = len(self.idx2word) - 1
+            # self.word2idx[word] = len(self.idx2word)
+        return self.word2idx[word]
+
+    def __len__(self):
+        return len(self.idx2word)
+
+
+class Corpus(object):
+
+    def __init__(self, path):
+        self.dictionary = Dictionary()
+        self.train = self.tokenize(os.path.join(path, 'train.tokens'))
+        self.valid = self.tokenize(os.path.join(path, 'valid.tokens'))
+        self.test = self.tokenize(os.path.join(path, 'test.tokens'))
+
+    def tokenize(self, path):
+        """Tokenizes a text file."""
+        assert os.path.exists(path)
+        # Add words to the dictionary
+        with open(path, 'r', encoding="utf8") as f:
+            for line in f:
+                words = line.split() + ['<eos>']
+                for word in words:
+                    self.dictionary.add_word(word)
+
+        # Tokenize file content
+        with open(path, 'r', encoding="utf8") as f:
+            idss = []
+            for line in f:
+                words = line.split() + ['<eos>']
+                ids = []
+                for word in words:
+                    ids.append(self.dictionary.word2idx[word])
+                idss.append(torch.tensor(ids).type(torch.int64))
+            # ids = torch.cat(idss)
+
+        return idss

--- a/egs/librispeech/asr/nnlm/local/download_lm_train_data.py
+++ b/egs/librispeech/asr/nnlm/local/download_lm_train_data.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+# Copyright (c)  2020  Xiaomi Corporation (author: Liyong Guo)
+# Apache 2.0
+
+import os
+import logging
+from google_drive_downloader import GoogleDriveDownloader as gdd
+from pathlib import Path
+
+# librispeech-lm-norm.txt is 4G
+# train_960_text is 48M, which is stands for the sum of {train_clean_360, train_clean_100, train_other_500}
+# here only train_960_text used to verify the whole pipeline
+# A copy of train_960_text: "htts://drive.google.com/file/d/1AgP4wTqbfp12dv4fJmjKXHdOf8eOtp_A/view?usp=sharing"
+# local_path: "/ceph-ly/open-source/snowfall/egs/librispeech/asr/simple_v1/data/local/lm_train/train_960_text"
+
+
+def download_librispeech_train_960_text():
+    train_960_text = "./data/lm_train/librispeech_train_960_text"
+    if not os.path.exists(train_960_text):
+        Path(os.path.dirname(train_960_text)).mkdir(parents=True,
+                                                    exist_ok=True)
+
+        logging.info("downloading train_960_text of librispeech.")
+        gdd.download_file_from_google_drive(
+            file_id='1AgP4wTqbfp12dv4fJmjKXHdOf8eOtp_A',
+            dest_path=train_960_text,
+            unzip=False)
+    else:
+        logging.info(
+            "train_960_text of librispeech is already downloaded. You may should check that"
+        )
+
+
+def main():
+    logging.getLogger().setLevel(logging.INFO)
+
+    download_librispeech_train_960_text()
+
+
+if __name__ == '__main__':
+    main()

--- a/egs/librispeech/asr/nnlm/local/huggingface_tokenizer.py
+++ b/egs/librispeech/asr/nnlm/local/huggingface_tokenizer.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+
+# Copyright (c)  2020  Xiaomi Corporation (author: Liyong Guo)
+# Apache 2.0
+
+# reference: https://huggingface.co/docs/tokenizers/python/latest/quicktour.html
+import argparse
+import logging
+import os
+import shutil
+from pathlib import Path
+from tokenizers import Tokenizer
+from tokenizers.models import WordPiece
+from tokenizers import normalizers
+from tokenizers.normalizers import Lowercase, NFD, StripAccents
+from tokenizers.pre_tokenizers import Whitespace
+from tokenizers.trainers import WordPieceTrainer
+from tokenizers import decoders
+
+
+def get_args():
+    parser = argparse.ArgumentParser(
+        description='train and tokenize with huggingface tokenizer')
+    parser.add_argument('--train-file',
+                        type=str,
+                        help="""file to train tokenizer""")
+    parser.add_argument('--vocab-size',
+                        type=int,
+                        default=1000,
+                        help="""number of tokens of the tokenizer""")
+    parser.add_argument('--tokenizer-path',
+                        type=str,
+                        help="path to save or load tokenizer")
+    parser.add_argument('--test-file',
+                        type=str,
+                        help="""file to be tokenized""")
+    args = parser.parse_args()
+    return args
+
+
+def train_tokenizer(train_files, save_path, vocab_size):
+    if os.path.exists(save_path):
+        logging.warning(
+            "{} already exists. Please check that.".format(save_path))
+        return
+    else:
+        Path(os.path.dirname(save_path)).mkdir(parents=True, exist_ok=True)
+
+    tokenizer = Tokenizer(WordPiece(unk_token='[UNK]'))
+    tokenizer.normalizer = normalizers.Sequence(
+        [NFD(), Lowercase(), StripAccents()])
+    tokenizer.pre_tokenizer = Whitespace()
+
+    # default vocab_size=30000
+    # here set vocab_size=1000 for accelerating
+    trainer = WordPieceTrainer(vocab_size=vocab_size, special_tokens=['[UNK]'])
+    tokenizer.train(train_files, trainer)
+    tokenizer.save(save_path)
+
+
+def tokenize_text(test_file, tokenizer_path):
+    if not os.path.exists(tokenizer_path):
+        logging.warning(
+            "Tokenizer {} does not exist. Please check that.".format(
+                tokenizer_path))
+        return
+    tokenizer = Tokenizer.from_file(tokenizer_path)
+    tokenizer.decoder = decoders.WordPiece()
+    tokenized_file = "{}.tokens".format(test_file)
+    # tokenized_ids = "{}.ids".format(test_file)
+    if os.path.exists(tokenized_file):
+        logging.warning(
+            "The input file seems already tokenized. Buckupping previous result"
+        )
+        shutil.copyfile(tokenized_file, "{}.bk".format(tokenized_file))
+    logging.warning("Tokenizing {}.".format(test_file))
+    fout = open(tokenized_file, 'w')
+    with open(test_file) as f:
+        for line in f:
+            line = line.strip()
+            output = tokenizer.encode(line)
+            fout.write(" ".join(output.tokens) + '\n')
+
+    fout.close()
+
+
+def main():
+    args = get_args()
+    if args.train_file is not None:
+        train_files = [args.train_file]
+        train_tokenizer(train_files, args.tokenizer_path, args.vocab_size)
+
+    if args.test_file is not None:
+        tokenize_text(args.test_file, args.tokenizer_path)
+
+
+if __name__ == '__main__':
+    main()

--- a/egs/librispeech/asr/nnlm/local/model.py
+++ b/egs/librispeech/asr/nnlm/local/model.py
@@ -1,0 +1,154 @@
+import math
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class RNNModel(nn.Module):
+    """Container module with an encoder, a recurrent module, and a decoder."""
+
+    def __init__(self, rnn_type, ntoken, ninp, nhid, nlayers, dropout=0.5, tie_weights=False):
+        super(RNNModel, self).__init__()
+        self.ntoken = ntoken
+        self.drop = nn.Dropout(dropout)
+        # import pdb; pdb.set_trace()
+        self.encoder = nn.Embedding(ntoken, ninp, padding_idx=0)
+        if rnn_type in ['LSTM', 'GRU']:
+            self.rnn = getattr(nn, rnn_type)(ninp, nhid, nlayers, dropout=dropout)
+        else:
+            try:
+                nonlinearity = {'RNN_TANH': 'tanh', 'RNN_RELU': 'relu'}[rnn_type]
+            except KeyError:
+                raise ValueError( """An invalid option for `--model` was supplied,
+                                 options are ['LSTM', 'GRU', 'RNN_TANH' or 'RNN_RELU']""")
+            self.rnn = nn.RNN(ninp, nhid, nlayers, nonlinearity=nonlinearity, dropout=dropout)
+        self.decoder = nn.Linear(nhid, ntoken)
+
+        # Optionally tie weights as in:
+        # "Using the Output Embedding to Improve Language Models" (Press & Wolf 2016)
+        # https://arxiv.org/abs/1608.05859
+        # and
+        # "Tying Word Vectors and Word Classifiers: A Loss Framework for Language Modeling" (Inan et al. 2016)
+        # https://arxiv.org/abs/1611.01462
+        if tie_weights:
+            if nhid != ninp:
+                raise ValueError('When using the tied flag, nhid must be equal to emsize')
+            self.decoder.weight = self.encoder.weight
+
+        self.init_weights()
+
+        self.rnn_type = rnn_type
+        self.nhid = nhid
+        self.nlayers = nlayers
+
+    def init_weights(self):
+        initrange = 0.1
+        nn.init.uniform_(self.encoder.weight, -initrange, initrange)
+        nn.init.zeros_(self.decoder.weight)
+        nn.init.uniform_(self.decoder.weight, -initrange, initrange)
+
+    def forward(self, input, hidden):
+        # import pdb; pdb.set_trace()
+        emb = self.drop(self.encoder(input))
+        output, hidden = self.rnn(emb, hidden)
+        output = self.drop(output)
+        decoded = self.decoder(output)
+        decoded = decoded.view(-1, self.ntoken)
+        return F.log_softmax(decoded, dim=1), hidden
+
+    def init_hidden(self, bsz):
+        weight = next(self.parameters())
+        if self.rnn_type == 'LSTM':
+            return (weight.new_zeros(self.nlayers, bsz, self.nhid),
+                    weight.new_zeros(self.nlayers, bsz, self.nhid))
+        else:
+            return weight.new_zeros(self.nlayers, bsz, self.nhid)
+
+# Temporarily leave PositionalEncoding module here. Will be moved somewhere else.
+class PositionalEncoding(nn.Module):
+    r"""Inject some information about the relative or absolute position of the tokens
+        in the sequence. The positional encodings have the same dimension as
+        the embeddings, so that the two can be summed. Here, we use sine and cosine
+        functions of different frequencies.
+    .. math::
+        \text{PosEncoder}(pos, 2i) = sin(pos/10000^(2i/d_model))
+        \text{PosEncoder}(pos, 2i+1) = cos(pos/10000^(2i/d_model))
+        \text{where pos is the word position and i is the embed idx)
+    Args:
+        d_model: the embed dim (required).
+        dropout: the dropout value (default=0.1).
+        max_len: the max. length of the incoming sequence (default=5000).
+    Examples:
+        >>> pos_encoder = PositionalEncoding(d_model)
+    """
+
+    def __init__(self, d_model, dropout=0.1, max_len=5000):
+        super(PositionalEncoding, self).__init__()
+        self.dropout = nn.Dropout(p=dropout)
+
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model))
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+        pe = pe.unsqueeze(0).transpose(0, 1)
+        self.register_buffer('pe', pe)
+
+    def forward(self, x):
+        r"""Inputs of forward function
+        Args:
+            x: the sequence fed to the positional encoder model (required).
+        Shape:
+            x: [sequence length, batch size, embed dim]
+            output: [sequence length, batch size, embed dim]
+        Examples:
+            >>> output = pos_encoder(x)
+        """
+
+        x = x + self.pe[:x.size(0), :]
+        return self.dropout(x)
+
+class TransformerModel(nn.Module):
+    """Container module with an encoder, a recurrent or transformer module, and a decoder."""
+
+    def __init__(self, ntoken, ninp, nhead, nhid, nlayers, dropout=0.5):
+        super(TransformerModel, self).__init__()
+        try:
+            from torch.nn import TransformerEncoder, TransformerEncoderLayer
+        except:
+            raise ImportError('TransformerEncoder module does not exist in PyTorch 1.1 or lower.')
+        self.model_type = 'Transformer'
+        self.src_mask = None
+        self.pos_encoder = PositionalEncoding(ninp, dropout)
+        encoder_layers = TransformerEncoderLayer(ninp, nhead, nhid, dropout)
+        self.transformer_encoder = TransformerEncoder(encoder_layers, nlayers)
+        self.encoder = nn.Embedding(ntoken, ninp)
+        self.ninp = ninp
+        self.decoder = nn.Linear(ninp, ntoken)
+
+        self.init_weights()
+
+    def _generate_square_subsequent_mask(self, sz):
+        mask = (torch.triu(torch.ones(sz, sz)) == 1).transpose(0, 1)
+        mask = mask.float().masked_fill(mask == 0, float('-inf')).masked_fill(mask == 1, float(0.0))
+        return mask
+
+    def init_weights(self):
+        initrange = 0.1
+        nn.init.uniform_(self.encoder.weight, -initrange, initrange)
+        nn.init.zeros_(self.decoder.weight)
+        nn.init.uniform_(self.decoder.weight, -initrange, initrange)
+
+    def forward(self, src, has_mask=True):
+        if has_mask:
+            device = src.device
+            if self.src_mask is None or self.src_mask.size(0) != len(src):
+                mask = self._generate_square_subsequent_mask(len(src)).to(device)
+                self.src_mask = mask
+        else:
+            self.src_mask = None
+
+        src = self.encoder(src) * math.sqrt(self.ninp)
+        src = self.pos_encoder(src)
+        output = self.transformer_encoder(src, self.src_mask)
+        output = self.decoder(output)
+        return F.log_softmax(output, dim=-1)

--- a/egs/librispeech/asr/nnlm/main.py
+++ b/egs/librispeech/asr/nnlm/main.py
@@ -1,0 +1,331 @@
+# coding: utf-8
+import argparse
+import time
+import math
+import os
+import sys
+import torch
+import torch.nn as nn
+import torch.onnx
+
+sys.path.insert(0, './local/')
+
+import data
+import model
+
+parser = argparse.ArgumentParser(
+    description='PyTorch Wikitext-2 RNN/LSTM/GRU/Transformer Language Model')
+parser.add_argument('--data',
+                    type=str,
+                    default='./data/lm_train/',
+                    help='location of the data corpus')
+parser.add_argument(
+    '--model',
+    type=str,
+    default='LSTM',
+    help='type of recurrent net (RNN_TANH, RNN_RELU, LSTM, GRU, Transformer)')
+parser.add_argument('--emsize',
+                    type=int,
+                    default=200,
+                    help='size of word embeddings')
+parser.add_argument('--nhid',
+                    type=int,
+                    default=200,
+                    help='number of hidden units per layer')
+parser.add_argument('--nlayers', type=int, default=2, help='number of layers')
+parser.add_argument('--lr',
+                    type=float,
+                    default=20,
+                    help='initial learning rate')
+parser.add_argument('--clip',
+                    type=float,
+                    default=0.25,
+                    help='gradient clipping')
+parser.add_argument('--epochs', type=int, default=40, help='upper epoch limit')
+parser.add_argument('--batch_size',
+                    type=int,
+                    default=30,
+                    metavar='N',
+                    help='batch size')
+parser.add_argument('--bptt', type=int, default=35, help='sequence length')
+parser.add_argument('--dropout',
+                    type=float,
+                    default=0.2,
+                    help='dropout applied to layers (0 = no dropout)')
+parser.add_argument('--tied',
+                    action='store_true',
+                    help='tie the word embedding and softmax weights')
+parser.add_argument('--seed', type=int, default=1111, help='random seed')
+parser.add_argument('--cuda', action='store_true', help='use CUDA')
+parser.add_argument('--log-interval',
+                    type=int,
+                    default=200,
+                    metavar='N',
+                    help='report interval')
+parser.add_argument('--save',
+                    type=str,
+                    default='model.pt',
+                    help='path to save the final model')
+parser.add_argument('--onnx-export',
+                    type=str,
+                    default='',
+                    help='path to export the final model in onnx format')
+
+parser.add_argument(
+    '--nhead',
+    type=int,
+    default=2,
+    help='the number of heads in the encoder/decoder of the transformer model')
+parser.add_argument('--dry-run',
+                    action='store_true',
+                    help='verify the code and the model')
+
+args = parser.parse_args()
+
+# Set the random seed manually for reproducibility.
+torch.manual_seed(args.seed)
+if torch.cuda.is_available():
+    if not args.cuda:
+        print(
+            "WARNING: You have a CUDA device, so you should probably run with --cuda"
+        )
+
+device = torch.device("cuda" if args.cuda else "cpu")
+
+###############################################################################
+# Load data
+###############################################################################
+
+corpus = data.Corpus(args.data)
+
+# Starting from sequential data, batchify arranges the dataset into columns.
+# For instance, with the alphabet as the sequence and batch size 4, we'd get
+# ┌ a g m s ┐
+# │ b h n t │
+# │ c i o u │
+# │ d j p v │
+# │ e k q w │
+# └ f l r x ┘.
+# These columns are treated as independent by the model, which means that the
+# dependence of e. g. 'g' on 'f' can not be learned, but allows more efficient
+# batch processing.
+
+
+def batchify(data, bsz):
+    # Work out how cleanly we can divide the dataset into bsz parts.
+    nbatch = len(data) // bsz
+    # Trim off any extra elements that wouldn't cleanly fit (remainders).
+    data = data.narrow(0, 0, nbatch * bsz)
+    # Evenly divide the data across the bsz batches.
+    data = data.view(bsz, -1).t().contiguous()
+    return data.to(device)
+
+
+eval_batch_size = args.batch_size
+# train_data = batchify(corpus.train, args.batch_size)
+# val_data = batchify(corpus.valid, eval_batch_size)
+# test_data = batchify(corpus.test, eval_batch_size)
+
+train_data = corpus.train
+val_data = corpus.valid
+test_data = corpus.test
+###############################################################################
+# Build the model
+###############################################################################
+
+ntokens = len(corpus.dictionary)
+if args.model == 'Transformer':
+    model = model.TransformerModel(ntokens, args.emsize, args.nhead, args.nhid,
+                                   args.nlayers, args.dropout).to(device)
+else:
+    model = model.RNNModel(args.model, ntokens, args.emsize, args.nhid,
+                           args.nlayers, args.dropout, args.tied).to(device)
+
+criterion = nn.NLLLoss(ignore_index=0)
+
+###############################################################################
+# Training code
+###############################################################################
+
+
+def repackage_hidden(h):
+    """Wraps hidden states in new Tensors, to detach them from their history."""
+
+    if isinstance(h, torch.Tensor):
+        return h.detach()
+    else:
+        return tuple(repackage_hidden(v) for v in h)
+
+
+# get_batch subdivides the source data into chunks of length args.bptt.
+# If source is equal to the example output of the batchify function, with
+# a bptt-limit of 2, we'd get the following two Variables for i = 0:
+# ┌ a g m s ┐ ┌ b h n t ┐
+# └ b h n t ┘ └ c i o u ┘
+# Note that despite the name of the function, the subdivison of data is not
+# done along the batch dimension (i.e. dimension 1), since that was handled
+# by the batchify function. The chunks are along dimension 0, corresponding
+# to the seq_len dimension in the LSTM.
+
+# def get_batch(source, i):
+#     seq_len = min(args.bptt, len(source) - 1 - i)
+#     data = source[i:i+seq_len]
+#     target = source[i+1:i+1+seq_len].view(-1)
+#     return data, target
+
+
+def get_batch(source, i, pad_index=0, batch_size=args.batch_size):
+    batch = source[i * batch_size:(i + 1) * batch_size]
+    # import pdb; pdb.set_trace()
+    seq_lens = [len(batch[i]) for i in range(batch_size)]
+    seq_len = max(seq_lens) + 1
+    data_padded = []
+    target = []
+    for data in batch:
+        # import pdb; pdb.set_trace()
+        # print("{} {}".format(seq_len,len(data)))
+        padding = torch.tensor([pad_index for _ in range(seq_len - len(data))])
+        data = torch.cat((data, padding), dim=0)
+        data_padded.append(data[:-1])
+        target.append(data[1:])
+
+    # import pdb; pdb.set_trace()
+    # data_padded: (Length, Batch_size)
+    # target: (Batch_size, Batch_size, Batch_size, ***)
+    try:
+        data_padded = torch.stack(data_padded).to(device).transpose(0, 1)
+        target = torch.flatten(torch.stack(target).to(device).transpose(0, 1))
+        return data_padded, target
+    except:
+        import pdb
+        pdb.set_trace()
+
+    #return torch.stack(data_padded).to(device), torch.stack(target).to(device)
+
+
+def evaluate(data_source):
+    # Turn on evaluation mode which disables dropout.
+    model.eval()
+    total_loss = 0.
+    ntokens = len(corpus.dictionary)
+    if args.model != 'Transformer':
+        hidden = model.init_hidden(eval_batch_size)
+    with torch.no_grad():
+        for i in range(0, len(data_source) // eval_batch_size - 1):
+            data, targets = get_batch(data_source, i)
+            if args.model == 'Transformer':
+                output = model(data)
+                output = output.view(-1, ntokens)
+            else:
+                output, hidden = model(data, hidden)
+                hidden = repackage_hidden(hidden)
+            total_loss += len(data) * criterion(output, targets).item()
+    return total_loss / (len(data_source) - 1)
+
+
+def train():
+    # Turn on training mode which enables dropout.
+    batch_size = args.batch_size
+    model.train()
+    total_loss = 0.
+    start_time = time.time()
+    ntokens = len(corpus.dictionary)
+    if args.model != 'Transformer':
+        hidden = model.init_hidden(batch_size)
+    for batch_idx in range(0, len(train_data) // batch_size - 1):
+        data, targets = get_batch(train_data, batch_idx)
+        # Starting each batch, we detach the hidden state from how it was previously produced.
+        # If we didn't, the model would try backpropagating all the way to start of the dataset.
+        model.zero_grad()
+        if args.model == 'Transformer':
+            output = model(data)
+            output = output.view(-1, ntokens)
+        else:
+            hidden = repackage_hidden(hidden)
+            output, hidden = model(data, hidden)
+
+        # import pdb; pdb.set_trace()
+        loss = criterion(output, targets)
+        loss.backward()
+
+        # `clip_grad_norm` helps prevent the exploding gradient problem in RNNs / LSTMs.
+        torch.nn.utils.clip_grad_norm_(model.parameters(), args.clip)
+        for p in model.parameters():
+            p.data.add_(p.grad, alpha=-lr)
+
+        #import pdb; pdb.set_trace()
+        total_loss += loss.item()
+
+        if batch_idx % args.log_interval == 0 and batch_idx > 0:
+            cur_loss = total_loss / args.log_interval
+            elapsed = time.time() - start_time
+            print(
+                '| epoch {:3d} | {:5d}/{:5d} batches | lr {:02.2f} | ms/batch {:5.2f} | '
+                'loss {:5.2f} | ppl {:8.2f}'.format(
+                    epoch, batch_idx,
+                    len(train_data) // batch_size, lr,
+                    elapsed * 1000 / args.log_interval, cur_loss,
+                    math.exp(cur_loss)))
+            total_loss = 0
+            start_time = time.time()
+        if args.dry_run:
+            break
+
+
+def export_onnx(path, batch_size, seq_len):
+    print('The model is also exported in ONNX format at {}'.format(
+        os.path.realpath(args.onnx_export)))
+    model.eval()
+    dummy_input = torch.LongTensor(seq_len * batch_size).zero_().view(
+        -1, batch_size).to(device)
+    hidden = model.init_hidden(batch_size)
+    torch.onnx.export(model, (dummy_input, hidden), path)
+
+
+# Loop over epochs.
+lr = args.lr
+best_val_loss = None
+
+# At any point you can hit Ctrl + C to break out of training early.
+try:
+    for epoch in range(1, args.epochs + 1):
+        epoch_start_time = time.time()
+        train()
+        val_loss = evaluate(val_data)
+        print('-' * 89)
+        print('| end of epoch {:3d} | time: {:5.2f}s | valid loss {:5.2f} | '
+              'valid ppl {:8.2f}'.format(epoch,
+                                         (time.time() - epoch_start_time),
+                                         val_loss, math.exp(val_loss)))
+        print('-' * 89)
+        # Save the model if the validation loss is the best we've seen so far.
+        if not best_val_loss or val_loss < best_val_loss:
+            with open(args.save, 'wb') as f:
+                torch.save(model, f)
+            best_val_loss = val_loss
+        else:
+            # Anneal the learning rate if no improvement has been seen in the validation dataset.
+            lr /= 4.0
+except KeyboardInterrupt:
+    print('-' * 89)
+    print('Exiting from training early')
+
+# Load the best saved model.
+with open(args.save, 'rb') as f:
+    model = torch.load(f)
+    # after load the rnn params are not a continuous chunk of memory
+    # this makes them a continuous chunk, and will speed up forward pass
+    # Currently, only rnn model supports flatten_parameters function.
+    if args.model in ['RNN_TANH', 'RNN_RELU', 'LSTM', 'GRU']:
+        model.rnn.flatten_parameters()
+
+# Run on test data.
+test_loss = evaluate(test_data)
+print('=' * 89)
+print('| End of training | test loss {:5.2f} | test ppl {:8.2f}'.format(
+    test_loss, math.exp(test_loss)))
+print('=' * 89)
+
+if len(args.onnx_export) > 0:
+    # Export the model in ONNX format.
+    export_onnx(args.onnx_export, batch_size=1, seq_len=args.bptt)

--- a/egs/librispeech/asr/nnlm/run.sh
+++ b/egs/librispeech/asr/nnlm/run.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Xiaomi Corporation (Author: Liyong Guo)
+# Apache 2.0
+
+# References:
+# https://github.com/kaldi-asr/kaldi/blob/master/scripts/rnnlm/train_rnnlm.sh
+# https://github.com/kaldi-asr/kaldi/blob/master/scripts/rnnlm/prepare_rnnlm_dir.sh
+# https://github.com/pytorch/examples/tree/master/word_language_model
+# https://huggingface.co/docs/tokenizers/python/latest/quicktour.html
+
+# Example of how to use HuggingFace tokenizer and train {RNN, Transformer} based LMs
+
+set -e
+stage=$1
+
+lm_train=data/lm_train/
+full_text=$lm_train/librispeech_train_960_text
+tokenizer=$lm_train/tokenizer-librispeech_train_960.json
+if [ $stage -eq 1 ]; then
+  python3 ./local/download_lm_train_data.py
+fi
+if [ $stage -eq 2 ]; then
+  echo "training tokenizer"
+  python3 local/huggingface_tokenizer.py \
+    --train-file=$full_text \
+    --tokenizer-path=$tokenizer
+fi
+
+if [ $stage -eq 3 ]; then
+  echo "tokenize a file"
+  python3 local/huggingface_tokenizer.py \
+    --test-file=$full_text \
+    --tokenizer-path=$tokenizer
+fi
+
+if [ $stage -eq 4 ]; then
+  echo "split all data into train/valid/test"
+
+  full_tokens=${full_text}.tokens
+  valid_test_fraction=10 # currently 5 percent for valid and 5 percent for test
+  valid_test_tokens=$lm_train/valid_test.tokens
+  train_tokens=$lm_train/train.tokens
+
+  num_utts_total=$(wc -l <$full_tokens )
+  num_valid_test=$(($num_utts_total/${valid_test_fraction}))
+  set +x
+  shuf -n $num_valid_test  $full_tokens > $valid_test_tokens
+
+  comm -3 <(sort $valid_test_tokens) <(sort $full_tokens) > $train_tokens
+  shuf -n $(($num_valid_test/2)) $valid_test_tokens > $lm_train/valid.tokens
+  comm -3 <(sort $lm_train/valid.tokens) <(sort $valid_test_tokens) > $lm_train/test.tokens
+
+fi
+
+
+if [ $stage -eq 5 ]; then
+  python main.py \
+    --cuda \
+    --model Transformer
+fi


### PR DESCRIPTION
Fixes #132

This commit is mainly about hugginface tokenizer and
a draft transformer/RNN based LM training pipeline.

They are implemented mainly by referencing the follwing tutorials: [tokenizer](https://huggingface.co/docs/tokenizers/python/latest/quicktour.html) and [neural  LM](https://github.com/pytorch/examples/tree/master/word_language_model) which is also [referenced by Espnet](https://github.com/espnet/espnet/blob/dab2092bc9c8e184c48cc6e603037333bd97dcd1/espnet2/lm/seq_rnn_lm.py#L16)

Current (tokenizer + transformer LM) experiment shows that the PPL can decrease from around 1000 to aroud 110 with 10 epochs, as shown by the following screenshots.



![255c9a5d80f4b3a38e86186936fcacd](https://user-images.githubusercontent.com/14951566/112467983-b1ac2780-8da2-11eb-8199-a634a9f332bb.png)
![d0e25a3ebc12a5e3a19c9d54e4fecfa](https://user-images.githubusercontent.com/14951566/112468001-b5d84500-8da2-11eb-98aa-a13a19c3a222.png)

TODOs: 
1. Extend this training pipeline with advanced utils, such as multi-thread prefetching Dataloader with proper collate_fn and tensorboard summary writer.
2. Evaluation/test parts
3. Do experiments with full Librispeech data. Currently only 50MB training text is used out of around 4GB.
4. A proper way to integrate NNLM into previous asr decode pipeline, i.e. the aim of the issue #132
5. Try other network structures.
