### PR TITLE
Rescoring with 4-gram LM

### DIFF
--- a/egs/librispeech/asr/simple_v1/RESULTS.md
+++ b/egs/librispeech/asr/simple_v1/RESULTS.md
@@ -390,6 +390,26 @@ Average over last 5 epochs, When using 40 filter banks instead of 80 (also twice
 2021-03-25 21:52:23,645 INFO [mmi_att_transformer_decode.py:329] [test-clean] %WER 6.93% [3645 / 52576, 529 ins, 308 del, 2808 sub ]
 2021-03-25 21:53:10,674 INFO [mmi_att_transformer_decode.py:329] [test-other] %WER 18.53% [9697 / 52343, 1136 ins, 929 del, 7632 sub ]
 
+## 2021-04-11
+
+By Fangjun.
+
+### Average over last 5 epochs
+
+#### LM rescoring with whole lattice
+
+$ ./mmi_att_transformer_decode.py --use-lm-rescoring=1 --num-path=-1 --max-duration=10 --output-beam-size=8
+2021-04-11 10:37:58,913 INFO [common.py:356] [test-clean] %WER 5.72% [3008 / 52576, 562 ins, 164 del, 2282 sub ]
+2021-04-11 10:46:03,670 INFO [common.py:356] [test-other] %WER 15.71% [8224 / 52343, 1331 ins, 562 del, 6331 sub ]
+
+#### LM rescoring with n-best list
+
+$ ./mmi_att_transformer_decode.py --use-lm-rescoring=1 --num-path=100 --max-duration=500 --output-beam-size=20
+2021-04-11 15:17:07,792 INFO [common.py:356] [test-clean] %WER 6.31% [3316 / 52576, 746 ins, 160 del, 2410 sub ]
+2021-04-11 15:19:48,583 INFO [common.py:356] [test-other] %WER 16.93% [8863 / 52343, 1649 ins, 514 del, 6700 sub ]
+
+
+
 ## 2021-03-08
 
 (Han Zhu): Results of <https://github.com/k2-fsa/snowfall/pull/119>

--- a/egs/librispeech/asr/simple_v1/RESULTS.md
+++ b/egs/librispeech/asr/simple_v1/RESULTS.md
@@ -398,15 +398,21 @@ By Fangjun.
 
 #### LM rescoring with whole lattice
 
+```
 $ ./mmi_att_transformer_decode.py --use-lm-rescoring=1 --num-path=-1 --max-duration=10 --output-beam-size=8
+
 2021-04-11 10:37:58,913 INFO [common.py:356] [test-clean] %WER 5.72% [3008 / 52576, 562 ins, 164 del, 2282 sub ]
 2021-04-11 10:46:03,670 INFO [common.py:356] [test-other] %WER 15.71% [8224 / 52343, 1331 ins, 562 del, 6331 sub ]
+```
 
 #### LM rescoring with n-best list
 
+```
 $ ./mmi_att_transformer_decode.py --use-lm-rescoring=1 --num-path=100 --max-duration=500 --output-beam-size=20
+
 2021-04-11 15:17:07,792 INFO [common.py:356] [test-clean] %WER 6.31% [3316 / 52576, 746 ins, 160 del, 2410 sub ]
 2021-04-11 15:19:48,583 INFO [common.py:356] [test-other] %WER 16.93% [8863 / 52343, 1649 ins, 514 del, 6700 sub ]
+```
 
 
 

--- a/egs/librispeech/asr/simple_v1/local/download_lm.sh
+++ b/egs/librispeech/asr/simple_v1/local/download_lm.sh
@@ -63,11 +63,18 @@ function check_and_download () {
 
 mkdir -p $dst_dir
 
-for f in 3-gram.pruned.1e-7.arpa.gz librispeech-vocab.txt librispeech-lexicon.txt; do
+files_to_download=(
+3-gram.pruned.1e-7.arpa.gz
+4-gram.arpa.gz
+librispeech-vocab.txt
+librispeech-lexicon.txt
+)
+for f in ${files_to_download[@]}; do
   check_and_download $f || exit 1
 done
 
 cd $dst_dir
 gunzip -c 3-gram.pruned.1e-7.arpa.gz > lm_tgmed.arpa
+gunzip -c 4-gram.arpa.gz > lm_fglarge.arpa
 
 exit 0

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
@@ -333,8 +333,6 @@ def main():
             G = k2.Fsa.from_dict(d).to(device)
 
         if num_paths is None:
-            # TODO(fangjun): remove this
-            assert False, 'Rescoring with whole lattice is currently not supported'
             # We are not going to use n-best list for rescoring.
             # Add epsilon self-loops to G.
             G = k2.add_epsilon_self_loops(G)

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
@@ -38,7 +38,6 @@ from snowfall.training.mmi_graph import get_phone_symbols
 def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
         device: Union[str, torch.device], HLG: Fsa, G: Fsa, num_paths: int,
         symbols: SymbolTable):
-    G = k2.arc_sort(G)  # It is a no-op if it is already sorted.
     tot_num_cuts = len(dataloader.dataset.cuts)
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)

--- a/egs/librispeech/asr/simple_v1/run.sh
+++ b/egs/librispeech/asr/simple_v1/run.sh
@@ -43,6 +43,12 @@ if [ $stage -le 4 ]; then
     --max-order=3 \
     data/local/lm/lm_tgmed.arpa >data/lang_nosp/G.fst.txt
 
+  python3 -m kaldilm \
+    --read-symbol-table="data/lang_nosp/words.txt" \
+    --disambig-symbol='#0' \
+    --max-order=4 \
+    data/local/lm/lm_fglarge.arpa >data/lang_nosp/G_4_gram.fst.txt
+
   echo ""
   echo "To load G:"
   echo "Use::"

--- a/snowfall/decoding/graph.py
+++ b/snowfall/decoding/graph.py
@@ -79,4 +79,11 @@ def compile_HLG(
     logging.info(
         f'LG is arc sorted: {(HLG.properties & k2.fsa_properties.ARC_SORTED) != 0}'
     )
+
+    # Attach a new attribute `lm_scores` so that we can recover
+    # the `am_scores` later.
+    # The scores on an arc consists of two parts:
+    #  scores = am_scores + lm_scores
+    # NOTE: we assume that both kinds of scores are in log-space.
+    HLG.lm_scores = HLG.scores.clone()
     return HLG

--- a/snowfall/decoding/lm_rescore.py
+++ b/snowfall/decoding/lm_rescore.py
@@ -255,9 +255,8 @@ def rescore_with_whole_lattice(lats: k2.Fsa,
 
 
 @torch.no_grad()
-def decode_with_lm_rescoring(lats: k2.Fsa,
-                             G: k2.Fsa,
-                             num_paths: Optional[int] = None) -> k2.Fsa:
+def decode_with_lm_rescoring(lats: k2.Fsa, G: k2.Fsa, num_paths: int,
+                             use_whole_lattice: bool) -> k2.Fsa:
     '''Decode using n-best list with LM rescoring.
 
     `lats` is a decoding lattice, which has 3 axes. This function first
@@ -275,13 +274,16 @@ def decode_with_lm_rescoring(lats: k2.Fsa,
         An FsaVec representing the language model (LM). Note that it
         is an FsaVec, but it contains only one Fsa.
       num_paths:
-        Optional, If not None, it is the size `n` in `n-best` list.
-        Otherwise, use the whole lattice for rescoring.
+        It is the size `n` in `n-best` list.
+        Used only if use_whole_lattice is False.
+      use_whole_lattice:
+        True to use whole lattice for rescoring. False to use n-best list
+        for rescoring.
     Returns:
       An FsaVec representing the best decoding path for each sequence
       in the lattice.
     '''
-    if num_paths is not None:
-        return rescore_with_n_best_list(lats, G, num_paths)
-    else:
+    if use_whole_lattice:
         return rescore_with_whole_lattice(lats, G)
+    else:
+        return rescore_with_n_best_list(lats, G, num_paths)

--- a/snowfall/decoding/lm_rescore.py
+++ b/snowfall/decoding/lm_rescore.py
@@ -168,7 +168,6 @@ def rescore_with_n_best_list(lats: k2.Fsa, G: k2.Fsa,
 
     # Use k2.index here since argmax_indexes' dtype is torch.int32
     best_path_indexes = k2.index(new2old, argmax_indexes)
-    #  best_path_indexes = argmax_indexes
 
     paths = k2.ragged.remove_axis(paths, 0)
 

--- a/snowfall/decoding/lm_rescore.py
+++ b/snowfall/decoding/lm_rescore.py
@@ -1,0 +1,269 @@
+# Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
+
+from typing import Optional
+
+import k2
+import torch
+
+
+def compute_am_scores(lats: k2.Fsa, word_fsas_with_epsilon_loops: k2.Fsa,
+                      path_to_seq_map: torch.Tensor) -> torch.Tensor:
+    '''Compute AM scores of n-best lists (represented as word_fsas).
+
+    Args:
+      lats:
+        An FsaVec, which is the output of `k2.intersect_dense_pruned`.
+        It must have the attribute `lm_scores`.
+      word_fsas_with_epsilon_loops:
+        An FsaVec representing a n-best list. Note that it has been processed
+        by `k2.add_epsilon_self_loops`.
+      path_to_seq_map:
+        A 1-D torch.Tensor with dtype torch.int32. path_to_seq_map[i] indicates
+        which sequence the i-th Fsa in word_fsas_with_epsilon_loops belongs to.
+        path_to_seq_map.numel() == word_fsas_with_epsilon_loops.arcs.dim0().
+    Returns:
+      Return a 1-D torch.Tensor containing the AM scores of each path.
+      `ans.numel() == word_fsas_with_epsilon_loops.shape[0]`
+    '''
+    device = lats.device
+    assert len(lats.shape) == 3
+    assert hasattr(lats, 'lm_scores')
+
+    # k2.compose() currently does not support b_to_a_map. To void
+    # replicating `lats`, we use k2.intersect_device here.
+    #
+    # lats has phone IDs as `labels` and word IDs as aux_labels, so we
+    # need to invert it here.
+    inverted_lats = k2.invert(lats)
+
+    # Now the `labels` of inverted_lats are word IDs (a 1-D torch.Tensor)
+    # and its `aux_labels` are phone IDs ( a k2.RaggedInt with 2 axes)
+
+    # Remove its `aux_labels` since it is not needed in the
+    # following computation
+    del inverted_lats.aux_labels
+    inverted_lats = k2.arc_sort(inverted_lats)
+
+    am_path_lats = k2.intersect_device(inverted_lats,
+                                       word_fsas_with_epsilon_loops,
+                                       b_to_a_map=path_to_seq_map,
+                                       sorted_match_a=True)
+
+    # NOTE: `k2.connect` and `k2.top_sort` support only CPU at present
+    am_path_lats = k2.top_sort(k2.connect(am_path_lats.to('cpu'))).to(device)
+
+    # The `scores` of every arc consists of `am_scores` and `lm_scores`
+    am_path_lats.scores = am_path_lats.scores - am_path_lats.lm_scores
+
+    am_scores = am_path_lats.get_tot_scores(True, True)
+
+    return am_scores
+
+
+@torch.no_grad()
+def rescore_with_n_best_list(lats: k2.Fsa, G: k2.Fsa,
+                             num_paths: int) -> k2.Fsa:
+    '''Decode using n-best list with LM rescoring.
+
+    `lats` is a decoding lattice, which has 3 axes. This function first
+    extracts `num_paths` paths from `lats` for each sequence using
+    `k2.random_paths`. The `am_scores` of these paths are computed.
+    For each path, its `lm_scores` is computed using `G` (which is an LM).
+    The final `tot_scores` is the sum of `am_scores` and `lm_scores`.
+    The path with the greatest `tot_scores` within a sequence is used
+    as the decoding output.
+
+    Args:
+      lats:
+        An FsaVec. It can be the output of `k2.intersect_dense_pruned`.
+      G:
+        An FsaVec representing the language model (LM). Note that it
+        is an FsaVec, but it contains only one Fsa.
+      num_paths:
+        It is the size `n` in `n-best` list.
+    Returns:
+      An FsaVec representing the best decoding path for each sequence
+      in the lattice.
+    '''
+    device = lats.device
+
+    assert len(lats.shape) == 3
+    assert hasattr(lats, 'aux_labels')
+    assert hasattr(lats, 'lm_scores')
+
+    assert G.shape == (1, None, None)
+    assert G.device == device
+    assert hasattr(G, 'aux_labels') is False
+
+    # First, extract `num_paths` paths for each sequence.
+    # paths is a k2.RaggedInt with axes [seq][path][arc_pos]
+    paths = k2.random_paths(lats, num_paths=num_paths, use_double_scores=True)
+
+    # word_seqs is a k2.RaggedInt sharing the same shape as `paths`
+    # but it contains word IDs. Note that it also contains 0s and -1s.
+    # The last entry in each sublist is -1.
+    word_seqs = k2.index(lats.aux_labels, paths)
+
+    # Remove epsilons and -1 from word_seqs
+    word_seqs = k2.ragged.remove_values_leq(word_seqs, 0)
+
+    # Remove repeated sequences to avoid redundant computation later.
+    #
+    # unique_word_seqs is still a k2.RaggedInt with 3 axes [seq][path][word]
+    # except that there are no repeated paths with the same word_seq
+    # within a seq.
+    #
+    # num_repeats is also a k2.RaggedInt with 2 axes containing the
+    # multiplicities of each path.
+    # num_repeats.num_elements() == unique_word_seqs.num_elements()
+    #
+    # Since k2.ragged.unique_sequences will reorder paths within a seq,
+    # `new2old` is a 1-D torch.Tensor mapping from the output path index
+    # to the input path index.
+    # new2old.numel() == unique_word_seqs.num_elements()
+    unique_word_seqs, num_repeats, new2old = k2.ragged.unique_sequences(
+        word_seqs, need_num_repeats=True, need_new2old_indexes=True)
+
+    seq_to_path_shape = k2.ragged.get_layer(unique_word_seqs.shape(), 0)
+
+    # path_to_seq_map is a 1-D torch.Tensor.
+    # path_to_seq_map[i] is the seq to which the i-th path
+    # belongs.
+    path_to_seq_map = seq_to_path_shape.row_ids(1)
+
+    # Remove the seq axis.
+    # Now unique_word_seqs has only two axes [path][word]
+    unique_word_seqs = k2.ragged.remove_axis(unique_word_seqs, 0)
+
+    # word_fsas is an FsaVec with axes [path][state][arc]
+    word_fsas = k2.linear_fsa(unique_word_seqs)
+
+    word_fsas_with_epsilon_loops = k2.add_epsilon_self_loops(word_fsas)
+
+    am_scores = compute_am_scores(lats, word_fsas_with_epsilon_loops,
+                                  path_to_seq_map)
+
+    # Now compute lm_scores
+    b_to_a_map = torch.zeros_like(path_to_seq_map)
+    lm_path_lats = k2.intersect_device(G,
+                                       word_fsas_with_epsilon_loops,
+                                       b_to_a_map=b_to_a_map,
+                                       sorted_match_a=True)
+    lm_path_lats = k2.top_sort(k2.connect(lm_path_lats.to('cpu'))).to(device)
+    lm_scores = lm_path_lats.get_tot_scores(True, True)
+
+    tot_scores = am_scores + lm_scores
+
+    # Remember that we used `k2.ragged.unique_sequences` to remove repeated
+    # paths to avoid redundant computation in `k2.intersect_device`.
+    # Now we use `num_repeats` to correct the scores for each path.
+    #
+    # NOTE(fangjun): It is commented out as it leads to a worse WER
+    # tot_scores = tot_scores * num_repeats.values()
+
+    # TODO(fangjun): We may need to add `k2.RaggedDouble`
+    ragged_tot_scores = k2.RaggedFloat(seq_to_path_shape,
+                                       tot_scores.to(torch.float32))
+    argmax_indexes = k2.ragged.argmax_per_sublist(ragged_tot_scores)
+
+    # Use k2.index here since argmax_indexes' dtype is torch.int32
+    best_path_indexes = k2.index(new2old, argmax_indexes)
+    #  best_path_indexes = argmax_indexes
+
+    paths = k2.ragged.remove_axis(paths, 0)
+
+    # best_path is a k2.RaggedInt with 2 axes [path][arc_pos]
+    best_paths = k2.index(paths, best_path_indexes)
+
+    # labels is a k2.RaggedInt with 2 axes [path][phone_id]
+    # Note that it contains -1s.
+    labels = k2.index(lats.labels.contiguous(), best_paths)
+
+    labels = k2.ragged.remove_values_eq(labels, -1)
+
+    # lats.aux_labels is a k2.RaggedInt tensor with 2 axes, so
+    # aux_labels is also a k2.RaggedInt with 2 axes
+    aux_labels = k2.index(lats.aux_labels, best_paths.values())
+
+    best_path_fsas = k2.linear_fsa(labels)
+    best_path_fsas.aux_labels = aux_labels
+
+    return best_path_fsas
+
+
+@torch.no_grad()
+def rescore_with_whole_lattice(lats: k2.Fsa,
+                               G_with_epsilon_loops: k2.Fsa) -> k2.Fsa:
+    '''Use whole lattice to rescore.
+
+    Args:
+      lats:
+        An FsaVec It can be the output of `k2.intersect_dense_pruned`.
+      G_with_epsilon_loops:
+        An FsaVec representing the language model (LM). Note that it
+        is an FsaVec, but it contains only one Fsa.
+    '''
+    assert len(lats.shape) == 3
+    assert hasattr(lats, 'lm_scores')
+    assert G_with_epsilon_loops.shape == (1, None, None)
+
+    device = lats.device
+    lats.scores = lats.scores - lats.lm_scores
+    # Now, lats.scores contains only am_scores
+
+    # inverted_lats has word IDs as labels.
+    # Its aux_labels are phone IDs, which is a ragged tensor k2.RaggedInt
+    inverted_lats = k2.invert(lats)
+    num_seqs = lats.shape[0]
+    inverted_lats_with_epsilon_loops = k2.add_epsilon_self_loops(inverted_lats)
+
+    b_to_a_map = torch.zeros(num_seqs, device=device, dtype=torch.int32)
+    rescoring_lats = k2.intersect_device(G_with_epsilon_loops,
+                                         inverted_lats_with_epsilon_loops,
+                                         b_to_a_map,
+                                         sorted_match_a=True)
+    rescoring_lats = k2.top_sort(k2.connect(
+        rescoring_lats.to('cpu'))).to(device)
+    inverted_rescoring_lats = k2.invert(rescoring_lats)
+    # inverted rescoring_lats has phone IDs as labels
+    # and word IDs as aux_labels.
+
+    # FIXME(fangjun): Use it when k2 is updated to support
+    # removing epsilon-self-loops
+    assert False, 'k2.shortest_path requires an acyclic FSA'
+    best_paths = k2.shortest_path(inverted_rescoring_lats,
+                                  use_double_scores=True)
+    return best_paths
+
+
+@torch.no_grad()
+def decode_with_lm_rescoring(lats: k2.Fsa,
+                             G: k2.Fsa,
+                             num_paths: Optional[int] = None) -> k2.Fsa:
+    '''Decode using n-best list with LM rescoring.
+
+    `lats` is a decoding lattice, which has 3 axes. This function first
+    extracts `num_paths` paths from `lats` for each sequence using
+    `k2.random_paths`. The `am_scores` of these paths are computed.
+    For each path, its `lm_scores` is computed using `G` (which is an LM).
+    The final `tot_scores` is the sum of `am_scores` and `lm_scores`.
+    The path with the greatest `tot_scores` within a sequence is used
+    as the decoding output.
+
+    Args:
+      lats:
+        An FsaVec It can be the output of `k2.intersect_dense_pruned`.
+      G:
+        An FsaVec representing the language model (LM). Note that it
+        is an FsaVec, but it contains only one Fsa.
+      num_paths:
+        Optional, If not None, it is the size `n` in `n-best` list.
+        Otherwise, use the whole lattice for rescoring.
+    Returns:
+      An FsaVec representing the best decoding path for each sequence
+      in the lattice.
+    '''
+    if num_paths is not None:
+        return rescore_with_n_best_list(lats, G, num_paths)
+    else:
+        return rescore_with_whole_lattice(lats, G)

--- a/snowfall/decoding/lm_rescore.py
+++ b/snowfall/decoding/lm_rescore.py
@@ -227,9 +227,8 @@ def rescore_with_whole_lattice(lats: k2.Fsa,
     # inverted rescoring_lats has phone IDs as labels
     # and word IDs as aux_labels.
 
-    # FIXME(fangjun): Use it when k2 is updated to support
-    # removing epsilon-self-loops
-    assert False, 'k2.shortest_path requires an acyclic FSA'
+    inverted_rescoring_lats = k2.remove_epsilon_self_loops(
+        inverted_rescoring_lats)
     best_paths = k2.shortest_path(inverted_rescoring_lats,
                                   use_double_scores=True)
     return best_paths


### PR DESCRIPTION
~Support for rescoring with the whole lattice is not added yet, as k2 does not support removing epsilon self-loops at present.~

Here are the WERs (%) using LM rescoring. You can see that rescoring with LM reduces WER.

## Base line (MMI conformer training)
It uses `k2.shortest_path` for decoding
- test_clean: 6.80
- test_other: 18.03

## With LM rescoring
It uses `k2.random_paths` with various `num_paths`

<img width="351" alt="Screen Shot 2021-04-05 at 1 23 36 PM" src="https://user-images.githubusercontent.com/5284924/113540174-276d8a00-9612-11eb-9641-cc933b7d80b0.png">
