### PR TITLE
Refactoring: data pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 
 data*/
+!snowfall/data
 exp*/
 
 .DS_Store

--- a/egs/aishell/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/aishell/asr/simple_v1/mmi_att_transformer_decode.py
@@ -17,8 +17,6 @@ from pathlib import Path
 from typing import List
 from typing import Union
 
-from lhotse import CutSet
-from lhotse.dataset import K2SpeechRecognitionDataset, SingleCutSampler
 from snowfall.common import average_checkpoint
 from snowfall.common import find_first_disambig_symbol
 from snowfall.common import get_texts

--- a/egs/aishell/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/aishell/asr/simple_v1/mmi_att_transformer_decode.py
@@ -24,6 +24,7 @@ from snowfall.common import find_first_disambig_symbol
 from snowfall.common import get_texts
 from snowfall.common import load_checkpoint
 from snowfall.common import setup_logger
+from snowfall.data import AishellAsrDataModule
 from snowfall.decoding.graph import compile_LG
 from snowfall.models import AcousticModel
 from snowfall.models.transformer import Transformer
@@ -199,11 +200,12 @@ def get_parser():
 
 
 def main():
-    args = get_parser().parse_args()
+    parser = get_parser()
+    AishellAsrDataModule.add_arguments(parser)
+    args = parser.parse_args()
 
     model_type = args.model_type
     epoch = args.epoch
-    max_frames = args.max_frames
     avg = args.avg
     att_rate = args.att_rate
 
@@ -289,16 +291,8 @@ def main():
         LG = k2.Fsa.from_dict(d)
 
     # load dataset
-    # feature_dir = Path('/export/gpudisk2/data/hegc/audio_workspace/snowfall_aishell1/exp/data')
-    feature_dir = Path('exp/data')
-    logging.debug("About to get test cuts")
-    cuts_test = CutSet.from_json(feature_dir / 'cuts_test.json.gz')
-
-    logging.debug("About to create test dataset")
-    test = K2SpeechRecognitionDataset(cuts_test)
-    sampler = SingleCutSampler(cuts_test, max_frames=max_frames)
-    logging.debug("About to create test dataloader")
-    test_dl = torch.utils.data.DataLoader(test, batch_size=None, sampler=sampler, num_workers=1)
+    aishell = AishellAsrDataModule(args)
+    test_dl = aishell.test_dataloaders()
 
     #  if not torch.cuda.is_available():
     #  logging.error('No GPU detected!')

--- a/egs/aishell/asr/simple_v1/mmi_att_transformer_train.py
+++ b/egs/aishell/asr/simple_v1/mmi_att_transformer_train.py
@@ -22,10 +22,8 @@ from torch.nn.utils import clip_grad_value_
 from torch.utils.tensorboard import SummaryWriter
 from typing import Dict, Optional, Tuple
 
-from lhotse import CutSet
-from lhotse.dataset import BucketingSampler, CutConcatenate, CutMix, K2SpeechRecognitionDataset, SingleCutSampler
 from lhotse.utils import fix_random_seed
-from snowfall.common import describe, str2bool
+from snowfall.common import describe
 from snowfall.common import load_checkpoint, save_checkpoint
 from snowfall.common import save_training_info
 from snowfall.common import setup_logger

--- a/egs/aishell/asr/simple_v1/mmi_att_transformer_train.py
+++ b/egs/aishell/asr/simple_v1/mmi_att_transformer_train.py
@@ -29,6 +29,7 @@ from snowfall.common import describe, str2bool
 from snowfall.common import load_checkpoint, save_checkpoint
 from snowfall.common import save_training_info
 from snowfall.common import setup_logger
+from snowfall.data.aishell import AishellAsrDataModule
 from snowfall.models import AcousticModel
 from snowfall.models.transformer import Noam, Transformer
 from snowfall.models.conformer import Conformer
@@ -367,11 +368,6 @@ def get_parser():
         default=0,
         help="Number of start epoch.")
     parser.add_argument(
-        '--max-frames',
-        type=int,
-        default=25000,
-        help="Maximum number of feature frames in a single batch.")
-    parser.add_argument(
         '--warm-step',
         type=int,
         default=25000,
@@ -402,51 +398,17 @@ def get_parser():
         type=int,
         default=256,
         help="Number of units in transformer attention layers.")
-    parser.add_argument(
-        '--bucketing_sampler',
-        type=str2bool,
-        default=False,
-        help='When enabled, the batches will come from buckets of '
-             'similar duration (saves padding frames).')
-    parser.add_argument(
-        '--num-buckets',
-        type=int,
-        default=30,
-        help='The number of buckets for the BucketingSampler'
-             '(you might want to increase it for larger datasets).')
-    parser.add_argument(
-        '--concatenate-cuts',
-        type=str2bool,
-        default=True,
-        help='When enabled, utterances (cuts) will be concatenated '
-             'to minimize the amount of padding.')
-    parser.add_argument(
-        '--duration-factor',
-        type=float,
-        default=1.0,
-        help='Determines the maximum duration of a concatenated cut '
-             'relative to the duration of the longest cut in a batch.')
-    parser.add_argument(
-        '--gap',
-        type=float,
-        default=1.0,
-        help='The amount of padding (in seconds) inserted between concatenated cuts. '
-             'This padding is filled with noise when noise augmentation is used.')
-    parser.add_argument(
-        '--full-libri',
-        type=str2bool,
-        default=False,
-        help='When enabled, use 960h LibriSpeech.')
     return parser
 
 
 def main():
-    args = get_parser().parse_args()
+    parser = get_parser()
+    AishellAsrDataModule.add_arguments(parser)
+    args = parser.parse_args()
 
     model_type = args.model_type
     start_epoch = args.start_epoch
     num_epochs = args.num_epochs
-    max_frames = args.max_frames
     accum_grad = args.accum_grad
     den_scale = args.den_scale
     att_rate = args.att_rate
@@ -485,57 +447,9 @@ def main():
     P.scores = torch.zeros_like(P.scores)
     P = P.to(device)
 
-    # load dataset
-    # feature_dir = Path('/export/gpudisk2/data/hegc/audio_workspace/snowfall_aishell1/exp/data')
-    feature_dir = Path('exp/data')
-    logging.info("About to get train cuts")
-    cuts_train = CutSet.from_json(feature_dir /
-                                  'cuts_train.json.gz')
-    logging.info("About to get dev cuts")
-    cuts_dev = CutSet.from_json(feature_dir / 'cuts_dev.json.gz')
-    logging.info("About to get Musan cuts")
-    cuts_musan = CutSet.from_json(feature_dir / 'cuts_musan.json.gz')
-
-    logging.info("About to create train dataset")
-    transforms = [CutMix(cuts=cuts_musan, prob=0.5, snr=(10, 20))]
-    if args.concatenate_cuts:
-        logging.info(f'Using cut concatenation with duration factor {args.duration_factor} and gap {args.gap}.')
-        # Cut concatenation should be the first transform in the list,
-        # so that if we e.g. mix noise in, it will fill the gaps between different utterances.
-        transforms = [CutConcatenate(duration_factor=args.duration_factor, gap=args.gap)] + transforms
-    train = K2SpeechRecognitionDataset(cuts_train, cut_transforms=transforms)
-    if args.bucketing_sampler:
-        logging.info('Using BucketingSampler.')
-        train_sampler = BucketingSampler(
-            cuts_train,
-            max_frames=max_frames,
-            shuffle=True,
-            num_buckets=args.num_buckets
-        )
-    else:
-        logging.info('Using SingleCutSampler.')
-        train_sampler = SingleCutSampler(
-            cuts_train,
-            max_frames=max_frames,
-            shuffle=True,
-        )
-    logging.info("About to create train dataloader")
-    train_dl = torch.utils.data.DataLoader(
-        train,
-        sampler=train_sampler,
-        batch_size=None,
-        num_workers=4
-    )
-    logging.info("About to create dev dataset")
-    validate = K2SpeechRecognitionDataset(cuts_dev)
-    valid_sampler = SingleCutSampler(cuts_dev, max_frames=max_frames)
-    logging.info("About to create dev dataloader")
-    valid_dl = torch.utils.data.DataLoader(
-        validate,
-        sampler=valid_sampler,
-        batch_size=None,
-        num_workers=1
-    )
+    aishell = AishellAsrDataModule(args)
+    train_dl = aishell.train_dataloaders()
+    valid_dl = aishell.valid_dataloaders()
 
     if not torch.cuda.is_available():
         logging.error('No GPU detected!')

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
@@ -290,7 +290,7 @@ def main():
     # load dataset
     librispeech = LibriSpeechAsrDataModule(args)
     test_sets = ['test-clean', 'test-other']
-    for test_set, test_dl in zip(test_sets, librispeech.train_dataloaders()):
+    for test_set, test_dl in zip(test_sets, librispeech.test_dataloaders()):
         logging.info(f'* DECODING: {test_set}')
 
         results = decode(dataloader=test_dl,

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
@@ -11,13 +11,10 @@ import numpy as np
 import os
 import torch
 from k2 import Fsa, SymbolTable
-from kaldialign import edit_distance
 from pathlib import Path
 from typing import List
 from typing import Union
 
-from lhotse import CutSet, load_manifest
-from lhotse.dataset import K2SpeechRecognitionDataset, SingleCutSampler
 from snowfall.common import average_checkpoint, store_transcripts
 from snowfall.common import find_first_disambig_symbol
 from snowfall.common import get_texts

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
@@ -24,6 +24,7 @@ from snowfall.common import get_texts
 from snowfall.common import write_error_stats
 from snowfall.common import load_checkpoint
 from snowfall.common import setup_logger
+from snowfall.data import LibriSpeechAsrDataModule
 from snowfall.decoding.graph import compile_HLG
 from snowfall.models import AcousticModel
 from snowfall.models.transformer import Transformer
@@ -170,11 +171,6 @@ def get_parser():
         default=10,
         help="Decoding epoch.")
     parser.add_argument(
-        '--max-duration',
-        type=int,
-        default=1000.0,
-        help="Maximum pooled recordings duration (seconds) in a single batch.")
-    parser.add_argument(
         '--avg',
         type=int,
         default=5,
@@ -199,11 +195,12 @@ def get_parser():
 
 
 def main():
-    args = get_parser().parse_args()
+    parser = get_parser()
+    LibriSpeechAsrDataModule.add_arguments(parser)
+    args = parser.parse_args()
 
     model_type = args.model_type
     epoch = args.epoch
-    max_duration = args.max_duration
     avg = args.avg
     att_rate = args.att_rate
 
@@ -294,22 +291,11 @@ def main():
     HLG.requires_grad_(False)
 
     # load dataset
-    feature_dir = Path('exp/data')
+    librispeech = LibriSpeechAsrDataModule(args)
     test_sets = ['test-clean', 'test-other']
-    for test_set in test_sets:
+    for test_set, test_dl in zip(test_sets, librispeech.train_dataloaders()):
         logging.info(f'* DECODING: {test_set}')
 
-        logging.debug("About to get test cuts")
-        cuts_test = load_manifest(feature_dir / f'cuts_{test_set}.json.gz')
-        logging.debug("About to create test dataset")
-        from lhotse.dataset.input_strategies import OnTheFlyFeatures
-        from lhotse import Fbank, FbankConfig
-        test = K2SpeechRecognitionDataset(cuts_test, input_strategy=OnTheFlyFeatures(Fbank(FbankConfig(num_mel_bins=80))))
-        sampler = SingleCutSampler(cuts_test, max_duration=max_duration)
-        logging.debug("About to create test dataloader")
-        test_dl = torch.utils.data.DataLoader(test, batch_size=None, sampler=sampler, num_workers=1)
-
-        logging.debug("About to decode")
         results = decode(dataloader=test_dl,
                          model=model,
                          device=device,
@@ -326,7 +312,6 @@ def main():
         with open(errs_filename, 'w') as f:
             write_error_stats(f, test_set, results)
         logging.info('Wrote detailed error stats to {}'.format(errs_filename))
-
 
 
 torch.set_num_threads(1)

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
@@ -27,7 +27,7 @@ from snowfall.common import describe, str2bool
 from snowfall.common import load_checkpoint, save_checkpoint
 from snowfall.common import save_training_info
 from snowfall.common import setup_logger
-from snowfall.data.librispeech import LibriSpeechDataModule
+from snowfall.data.librispeech import LibriSpeechAsrDataModule, LibriSpeechDataModule
 from snowfall.models import AcousticModel
 from snowfall.models.conformer import Conformer
 from snowfall.models.transformer import Noam, Transformer
@@ -404,7 +404,7 @@ def get_parser():
 
 def main():
     parser = get_parser()
-    LibriSpeechDataModule.add_arguments(parser)
+    LibriSpeechAsrDataModule.add_arguments(parser)
     args = parser.parse_args()
 
     model_type = args.model_type
@@ -448,7 +448,7 @@ def main():
     P.scores = torch.zeros_like(P.scores)
     P = P.to(device)
 
-    librispeech = LibriSpeechDataModule(args)
+    librispeech = LibriSpeechAsrDataModule(args)
     train_dl = librispeech.train_dataloaders()
     valid_dl = librispeech.valid_dataloaders()
 

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_train.py
@@ -27,7 +27,7 @@ from snowfall.common import describe, str2bool
 from snowfall.common import load_checkpoint, save_checkpoint
 from snowfall.common import save_training_info
 from snowfall.common import setup_logger
-from snowfall.data.librispeech import LibriSpeechAsrDataModule, LibriSpeechDataModule
+from snowfall.data.librispeech import LibriSpeechAsrDataModule
 from snowfall.models import AcousticModel
 from snowfall.models.conformer import Conformer
 from snowfall.models.transformer import Noam, Transformer

--- a/snowfall/data/__init__.py
+++ b/snowfall/data/__init__.py
@@ -1,2 +1,4 @@
+from .aishell import AishellAsrDataModule
+from .asr_datamodule import AsrDataModule
 from .datamodule import DataModule
-from .librispeech import LibriSpeechDataModule
+from .librispeech import LibriSpeechAsrDataModule

--- a/snowfall/data/__init__.py
+++ b/snowfall/data/__init__.py
@@ -1,0 +1,2 @@
+from .datamodule import DataModule
+from .librispeech import LibriSpeechDataModule

--- a/snowfall/data/aishell.py
+++ b/snowfall/data/aishell.py
@@ -16,12 +16,12 @@ class AishellAsrDataModule(AsrDataModule):
 
     @lru_cache()
     def valid_cuts(self) -> CutSet:
-        logging.info("About to get train cuts")
+        logging.info("About to get valid cuts")
         return load_manifest(self.args.feature_dir / 'cuts_dev.json.gz')
 
     @lru_cache()
     def test_cuts(self) -> CutSet:
-        logging.info("About to get train cuts")
+        logging.info("About to get test cuts")
         return load_manifest(self.args.feature_dir / 'cuts_test.json.gz')
 
 

--- a/snowfall/data/aishell.py
+++ b/snowfall/data/aishell.py
@@ -2,7 +2,7 @@ import logging
 from functools import lru_cache
 
 from lhotse import CutSet, load_manifest
-from snowfall.data import AsrDataModule
+from snowfall.data.asr_datamodule import AsrDataModule
 
 
 class AishellAsrDataModule(AsrDataModule):

--- a/snowfall/data/aishell.py
+++ b/snowfall/data/aishell.py
@@ -1,0 +1,27 @@
+import logging
+from functools import lru_cache
+
+from lhotse import CutSet, load_manifest
+from snowfall.data import AsrDataModule
+
+
+class AishellAsrDataModule(AsrDataModule):
+    """
+    Aishell ASR data module.
+    """
+    @lru_cache()
+    def train_cuts(self) -> CutSet:
+        logging.info("About to get train cuts")
+        return load_manifest(self.args.feature_dir / 'cuts_train.json.gz')
+
+    @lru_cache()
+    def valid_cuts(self) -> CutSet:
+        logging.info("About to get train cuts")
+        return load_manifest(self.args.feature_dir / 'cuts_dev.json.gz')
+
+    @lru_cache()
+    def test_cuts(self) -> CutSet:
+        logging.info("About to get train cuts")
+        return load_manifest(self.args.feature_dir / 'cuts_test.json.gz')
+
+

--- a/snowfall/data/asr_datamodule.py
+++ b/snowfall/data/asr_datamodule.py
@@ -1,0 +1,202 @@
+import argparse
+
+from typing import List, Union
+
+import logging
+
+from torch.utils.data import DataLoader
+
+from lhotse import Fbank, FbankConfig, load_manifest
+from lhotse.dataset import BucketingSampler, CutConcatenate, CutMix, K2SpeechRecognitionDataset, SingleCutSampler, \
+    SpecAugment
+from lhotse.dataset.input_strategies import OnTheFlyFeatures
+from snowfall.common import str2bool
+from snowfall.data.datamodule import DataModule
+
+
+class AsrDataModule(DataModule):
+    """
+    DataModule for K2 ASR experiments.
+    It assumes there is always one train and valid dataloader,
+    but there can be multiple test dataloaders (e.g. LibriSpeech test-clean and test-other).
+
+    It contains all the common data pipeline modules used in ASR experiments, e.g.:
+    - dynamic batch size,
+    - bucketing samplers,
+    - cut concatenation,
+    - augmentation,
+    - on-the-fly feature extraction
+
+    This class should be derived for specific corpora used in ASR tasks.
+    """
+
+    def add_arguments(self, parser: argparse.ArgumentParser):
+        super().add_arguments(parser)
+        group = parser.add_argument_group(
+            title='ASR data related options',
+            description='These options are used for the preparation of PyTorch DataLoaders '
+                        'from Lhotse CutSet\'s -- they control the effective batch sizes, '
+                        'sampling strategies, applied data augmentations, etc.'
+        )
+        group.add_argument(
+            '--max-duration',
+            type=int,
+            default=500.0,
+            help="Maximum pooled recordings duration (seconds) in a single batch.")
+        group.add_argument(
+            '--bucketing-sampler',
+            type=str2bool,
+            default=False,
+            help='When enabled, the batches will come from buckets of '
+                 'similar duration (saves padding frames).')
+        group.add_argument(
+            '--num-buckets',
+            type=int,
+            default=30,
+            help='The number of buckets for the BucketingSampler'
+                 '(you might want to increase it for larger datasets).')
+        group.add_argument(
+            '--concatenate-cuts',
+            type=str2bool,
+            default=True,
+            help='When enabled, utterances (cuts) will be concatenated '
+                 'to minimize the amount of padding.')
+        group.add_argument(
+            '--duration-factor',
+            type=float,
+            default=1.0,
+            help='Determines the maximum duration of a concatenated cut '
+                 'relative to the duration of the longest cut in a batch.')
+        group.add_argument(
+            '--gap',
+            type=float,
+            default=1.0,
+            help='The amount of padding (in seconds) inserted between concatenated cuts. '
+                 'This padding is filled with noise when noise augmentation is used.')
+        group.add_argument(
+            '--on-the-fly-feats',
+            type=str2bool,
+            default=False,
+            help='When enabled, use on-the-fly cut mixing and feature extraction. '
+                 'Will drop existing precomputed feature manifests if available.'
+        )
+
+    def train_dataloaders(self) -> DataLoader:
+        logging.info("About to get train cuts")
+        cuts_train = self.train_cuts()
+
+        logging.info("About to get Musan cuts")
+        cuts_musan = load_manifest(self.args.feature_dir / 'cuts_musan.json.gz')
+
+        logging.info("About to create train dataset")
+        transforms = [CutMix(cuts=cuts_musan, prob=0.5, snr=(10, 20))]
+        if self.args.concatenate_cuts:
+            logging.info(f'Using cut concatenation with duration factor '
+                         f'{self.args.duration_factor} and gap {self.args.gap}.')
+            # Cut concatenation should be the first transform in the list,
+            # so that if we e.g. mix noise in, it will fill the gaps between different utterances.
+            transforms = [
+                             CutConcatenate(
+                                 duration_factor=self.args.duration_factor,
+                                 gap=self.args.gap
+                             )
+                         ] + transforms
+
+        input_transforms = [
+            SpecAugment(num_frame_masks=2, features_mask_size=27, num_feature_masks=2, frames_mask_size=100)
+        ]
+
+        train = K2SpeechRecognitionDataset(
+            cuts_train,
+            cut_transforms=transforms,
+            input_transforms=input_transforms
+        )
+
+        if self.args.on_the_fly_feats:
+            # NOTE: the PerturbSpeed transform should be added only if we remove it from data prep stage.
+            # # Add on-the-fly speed perturbation; since originally it would have increased epoch
+            # # size by 3, we will apply prob 2/3 and use 3x more epochs.
+            # # Speed perturbation probably should come first before concatenation,
+            # # but in principle the transforms order doesn't have to be strict (e.g. could be randomized)
+            # transforms = [PerturbSpeed(factors=[0.9, 1.1], p=2 / 3)] + transforms
+            # Drop feats to be on the safe side.
+            cuts_train = cuts_train.drop_features()
+            train = K2SpeechRecognitionDataset(
+                cuts=cuts_train,
+                cut_transforms=transforms,
+                input_strategy=OnTheFlyFeatures(Fbank(FbankConfig(num_mel_bins=80))),
+                input_transforms=input_transforms
+            )
+
+        if self.args.bucketing_sampler:
+            logging.info('Using BucketingSampler.')
+            train_sampler = BucketingSampler(
+                cuts_train,
+                max_duration=self.args.max_duration,
+                shuffle=True,
+                num_buckets=self.args.num_buckets
+            )
+        else:
+            logging.info('Using SingleCutSampler.')
+            train_sampler = SingleCutSampler(
+                cuts_train,
+                max_duration=self.args.max_duration,
+                shuffle=True,
+            )
+        logging.info("About to create train dataloader")
+        train_dl = DataLoader(
+            train,
+            sampler=train_sampler,
+            batch_size=None,
+            num_workers=4,
+        )
+        return train_dl
+
+    def valid_dataloaders(self) -> DataLoader:
+        logging.info("About to get dev cuts")
+        cuts_valid = self.valid_cuts()
+
+        logging.info("About to create dev dataset")
+        if self.args.on_the_fly_feats:
+            cuts_valid = cuts_valid.drop_features()
+            validate = K2SpeechRecognitionDataset(
+                cuts_valid.drop_features(),
+                input_strategy=OnTheFlyFeatures(Fbank(FbankConfig(num_mel_bins=80)))
+            )
+        else:
+            validate = K2SpeechRecognitionDataset(cuts_valid)
+        valid_sampler = SingleCutSampler(
+            cuts_valid,
+            max_duration=self.args.max_duration,
+        )
+        logging.info("About to create dev dataloader")
+        valid_dl = DataLoader(
+            validate,
+            sampler=valid_sampler,
+            batch_size=None,
+            num_workers=1
+        )
+        return valid_dl
+
+    def test_dataloaders(self) -> Union[DataLoader, List[DataLoader]]:
+        cuts = self.test_cuts()
+        is_list = isinstance(cuts, list)
+        test_loaders = []
+        if not is_list:
+            cuts = [cuts]
+
+        for cuts_test in cuts:
+            logging.debug("About to create test dataset")
+            test = K2SpeechRecognitionDataset(
+                cuts_test,
+                input_strategy=OnTheFlyFeatures(Fbank(FbankConfig(num_mel_bins=80)))
+            )
+            sampler = SingleCutSampler(cuts_test, max_duration=self.args.max_duration)
+            logging.debug("About to create test dataloader")
+            test_dl = DataLoader(test, batch_size=None, sampler=sampler, num_workers=1)
+            test_loaders.append(test_dl)
+
+        if is_list:
+            return test_loaders
+        else:
+            return test_loaders[0]

--- a/snowfall/data/asr_datamodule.py
+++ b/snowfall/data/asr_datamodule.py
@@ -30,7 +30,8 @@ class AsrDataModule(DataModule):
     This class should be derived for specific corpora used in ASR tasks.
     """
 
-    def add_arguments(self, parser: argparse.ArgumentParser):
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser):
         super().add_arguments(parser)
         group = parser.add_argument_group(
             title='ASR data related options',

--- a/snowfall/data/asr_datamodule.py
+++ b/snowfall/data/asr_datamodule.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import argparse
 
 from typing import List, Union
@@ -38,6 +40,12 @@ class AsrDataModule(DataModule):
             description='These options are used for the preparation of PyTorch DataLoaders '
                         'from Lhotse CutSet\'s -- they control the effective batch sizes, '
                         'sampling strategies, applied data augmentations, etc.'
+        )
+        group.add_argument(
+            '--feature-dir',
+            type=Path,
+            default=Path('exp/data'),
+            help='Path to directory with train/valid/test cuts.'
         )
         group.add_argument(
             '--max-duration',

--- a/snowfall/data/datamodule.py
+++ b/snowfall/data/datamodule.py
@@ -1,0 +1,18 @@
+from torch.utils.data import DataLoader
+from typing import Iterable, Union
+
+import argparse
+
+
+class DataModule:
+    def __init__(self, args: argparse.Namespace):
+        self.args = args
+
+    def train_dataloaders(self) -> Union[DataLoader, Iterable[DataLoader]]:
+        raise NotImplementedError()
+
+    def valid_dataloaders(self) -> Union[DataLoader, Iterable[DataLoader]]:
+        raise NotImplementedError()
+
+    def test_dataloaders(self) -> Union[DataLoader, Iterable[DataLoader]]:
+        raise NotImplementedError()

--- a/snowfall/data/datamodule.py
+++ b/snowfall/data/datamodule.py
@@ -1,18 +1,41 @@
 from torch.utils.data import DataLoader
-from typing import Iterable, Union
+from typing import List, Union
 
 import argparse
 
+from lhotse import CutSet
+
 
 class DataModule:
+    """
+    Contains dataset-related code. It is intended to read/construct Lhotse cuts,
+    and create Dataset/Sampler/DataLoader out of them.
+
+    There is a separate method to create each of train/valid/test DataLoader.
+    In principle, there might be multiple DataLoaders for each of train/valid/test
+    (e.g. when a corpus has multiple test sets).
+    The API of this class allows to return lists of CutSets/DataLoaders.
+    """
     def __init__(self, args: argparse.Namespace):
         self.args = args
 
-    def train_dataloaders(self) -> Union[DataLoader, Iterable[DataLoader]]:
+    def add_arguments(self, parser: argparse.ArgumentParser):
+        pass
+
+    def train_cuts(self) -> Union[CutSet, List[CutSet]]:
         raise NotImplementedError()
 
-    def valid_dataloaders(self) -> Union[DataLoader, Iterable[DataLoader]]:
+    def valid_cuts(self) -> Union[CutSet, List[CutSet]]:
         raise NotImplementedError()
 
-    def test_dataloaders(self) -> Union[DataLoader, Iterable[DataLoader]]:
+    def test_cuts(self) -> Union[CutSet, List[CutSet]]:
+        raise NotImplementedError()
+
+    def train_dataloaders(self) -> Union[DataLoader, List[DataLoader]]:
+        raise NotImplementedError()
+
+    def valid_dataloaders(self) -> Union[DataLoader, List[DataLoader]]:
+        raise NotImplementedError()
+
+    def test_dataloaders(self) -> Union[DataLoader, List[DataLoader]]:
         raise NotImplementedError()

--- a/snowfall/data/datamodule.py
+++ b/snowfall/data/datamodule.py
@@ -19,7 +19,8 @@ class DataModule:
     def __init__(self, args: argparse.Namespace):
         self.args = args
 
-    def add_arguments(self, parser: argparse.ArgumentParser):
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser):
         pass
 
     def train_cuts(self) -> Union[CutSet, List[CutSet]]:

--- a/snowfall/data/librispeech.py
+++ b/snowfall/data/librispeech.py
@@ -1,0 +1,191 @@
+from typing import List
+
+import logging
+
+import argparse
+from torch.utils.data import DataLoader
+
+from lhotse import Fbank, FbankConfig, load_manifest
+from lhotse.dataset import BucketingSampler, CutConcatenate, CutMix, K2SpeechRecognitionDataset, SingleCutSampler, \
+    SpecAugment
+from lhotse.dataset.input_strategies import OnTheFlyFeatures
+from snowfall.common import str2bool
+from snowfall.data.datamodule import DataModule
+
+
+class LibriSpeechDataModule(DataModule):
+    def add_arguments(self, parser: argparse.ArgumentParser):
+        group = parser.add_argument_group(
+            title='Data related options',
+            description='These options are used for the preparation of PyTorch DataLoaders '
+                        'from Lhotse CutSet\'s -- they control the effective batch sizes, '
+                        'sampling strategies, applied data augmentations, etc.'
+        )
+        group.add_argument(
+            '--max-duration',
+            type=int,
+            default=500.0,
+            help="Maximum pooled recordings duration (seconds) in a single batch.")
+        group.add_argument(
+            '--bucketing_sampler',
+            type=str2bool,
+            default=False,
+            help='When enabled, the batches will come from buckets of '
+                 'similar duration (saves padding frames).')
+        group.add_argument(
+            '--num-buckets',
+            type=int,
+            default=30,
+            help='The number of buckets for the BucketingSampler'
+                 '(you might want to increase it for larger datasets).')
+        group.add_argument(
+            '--concatenate-cuts',
+            type=str2bool,
+            default=True,
+            help='When enabled, utterances (cuts) will be concatenated '
+                 'to minimize the amount of padding.')
+        group.add_argument(
+            '--duration-factor',
+            type=float,
+            default=1.0,
+            help='Determines the maximum duration of a concatenated cut '
+                 'relative to the duration of the longest cut in a batch.')
+        group.add_argument(
+            '--gap',
+            type=float,
+            default=1.0,
+            help='The amount of padding (in seconds) inserted between concatenated cuts. '
+                 'This padding is filled with noise when noise augmentation is used.')
+        group.add_argument(
+            '--full-libri',
+            type=str2bool,
+            default=False,
+            help='When enabled, use 960h LibriSpeech.')
+        group.add_argument(
+            '--on-the-fly-feats',
+            type=str2bool,
+            default=False,
+            help='When enabled, use on-the-fly cut mixing and feature extraction. '
+                 'Will drop existing precomputed feature manifests if available.'
+        )
+
+    def train_dataloaders(self) -> DataLoader:
+        logging.info("About to get train cuts")
+        cuts_train = load_manifest(self.args.feature_dir / 'cuts_train-clean-100.json.gz')
+        if self.args.full_libri:
+            cuts_train = (
+                    cuts_train +
+                    load_manifest(self.args.feature_dir / 'cuts_train-clean-360.json.gz') +
+                    load_manifest(self.args.feature_dir / 'cuts_train-other-500.json.gz')
+            )
+
+        logging.info("About to get Musan cuts")
+        cuts_musan = load_manifest(self.args.feature_dir / 'cuts_musan.json.gz')
+
+        logging.info("About to create train dataset")
+        transforms = [CutMix(cuts=cuts_musan, prob=0.5, snr=(10, 20))]
+        if self.args.concatenate_cuts:
+            logging.info(f'Using cut concatenation with duration factor '
+                         f'{self.args.duration_factor} and gap {self.args.gap}.')
+            # Cut concatenation should be the first transform in the list,
+            # so that if we e.g. mix noise in, it will fill the gaps between different utterances.
+            transforms = [
+                CutConcatenate(
+                    duration_factor=self.args.duration_factor,
+                    gap=self.args.gap
+                )
+             ] + transforms
+
+        input_transforms = [
+            SpecAugment(num_frame_masks=2, features_mask_size=27, num_feature_masks=2, frames_mask_size=100)
+        ]
+
+        train = K2SpeechRecognitionDataset(
+            cuts_train,
+            cut_transforms=transforms,
+            input_transforms=input_transforms
+        )
+
+        if self.args.on_the_fly_feats:
+            # NOTE: the PerturbSpeed transform should be added only if we remove it from data prep stage.
+            # # Add on-the-fly speed perturbation; since originally it would have increased epoch
+            # # size by 3, we will apply prob 2/3 and use 3x more epochs.
+            # # Speed perturbation probably should come first before concatenation,
+            # # but in principle the transforms order doesn't have to be strict (e.g. could be randomized)
+            # transforms = [PerturbSpeed(factors=[0.9, 1.1], p=2 / 3)] + transforms
+            # Drop feats to be on the safe side.
+            cuts_train = cuts_train.drop_features()
+            train = K2SpeechRecognitionDataset(
+                cuts=cuts_train,
+                cut_transforms=transforms,
+                input_strategy=OnTheFlyFeatures(Fbank(FbankConfig(num_mel_bins=80))),
+                input_transforms=input_transforms
+            )
+
+        if self.args.bucketing_sampler:
+            logging.info('Using BucketingSampler.')
+            train_sampler = BucketingSampler(
+                cuts_train,
+                max_duration=self.args.max_duration,
+                shuffle=True,
+                num_buckets=self.args.num_buckets
+            )
+        else:
+            logging.info('Using SingleCutSampler.')
+            train_sampler = SingleCutSampler(
+                cuts_train,
+                max_duration=self.args.max_duration,
+                shuffle=True,
+            )
+        logging.info("About to create train dataloader")
+        train_dl = DataLoader(
+            train,
+            sampler=train_sampler,
+            batch_size=None,
+            num_workers=4,
+        )
+        return train_dl
+
+    def valid_dataloaders(self) -> DataLoader:
+        logging.info("About to get dev cuts")
+        cuts_dev = (
+                load_manifest(self.feature_dir / 'cuts_dev-clean.json.gz') +
+                load_manifest(self.feature_dir / 'cuts_dev-other.json.gz')
+        )
+
+        logging.info("About to create dev dataset")
+        if self.args.on_the_fly_feats:
+            cuts_dev = cuts_dev.drop_features()
+            validate = K2SpeechRecognitionDataset(
+                cuts_dev.drop_features(),
+                input_strategy=OnTheFlyFeatures(Fbank(FbankConfig(num_mel_bins=80)))
+            )
+        else:
+            validate = K2SpeechRecognitionDataset(cuts_dev)
+        valid_sampler = SingleCutSampler(
+            cuts_dev,
+            max_duration=self.args.max_duration,
+        )
+        logging.info("About to create dev dataloader")
+        valid_dl = DataLoader(
+            validate,
+            sampler=valid_sampler,
+            batch_size=None,
+            num_workers=1
+        )
+        return valid_dl
+
+    def test_dataloaders(self) -> List[DataLoader]:
+        test_sets = ['test-clean', 'test-other']
+        for test_set in test_sets:
+            logging.debug("About to get test cuts")
+            cuts_test = load_manifest(self.args.feature_dir / f'cuts_{test_set}.json.gz')
+            logging.debug("About to create test dataset")
+            test = K2SpeechRecognitionDataset(
+                cuts_test,
+                input_strategy=OnTheFlyFeatures(Fbank(FbankConfig(num_mel_bins=80)))
+            )
+            sampler = SingleCutSampler(cuts_test, max_duration=self.args.max_duration)
+            logging.debug("About to create test dataloader")
+            test_dl = DataLoader(test, batch_size=None, sampler=sampler, num_workers=1)
+            yield test_dl

--- a/snowfall/data/librispeech.py
+++ b/snowfall/data/librispeech.py
@@ -42,8 +42,8 @@ class LibriSpeechAsrDataModule(AsrDataModule):
     def valid_cuts(self) -> CutSet:
         logging.info("About to get dev cuts")
         cuts_valid = (
-                load_manifest(self.feature_dir / 'cuts_dev-clean.json.gz') +
-                load_manifest(self.feature_dir / 'cuts_dev-other.json.gz')
+                load_manifest(self.args.feature_dir / 'cuts_dev-clean.json.gz') +
+                load_manifest(self.args.feature_dir / 'cuts_dev-other.json.gz')
         )
         return cuts_valid
 

--- a/snowfall/data/librispeech.py
+++ b/snowfall/data/librispeech.py
@@ -1,75 +1,32 @@
-from typing import List
+import argparse
+
+from functools import lru_cache
 
 import logging
+from typing import List
 
-import argparse
-from torch.utils.data import DataLoader
-
-from lhotse import Fbank, FbankConfig, load_manifest
-from lhotse.dataset import BucketingSampler, CutConcatenate, CutMix, K2SpeechRecognitionDataset, SingleCutSampler, \
-    SpecAugment
-from lhotse.dataset.input_strategies import OnTheFlyFeatures
+from lhotse import CutSet, load_manifest
 from snowfall.common import str2bool
-from snowfall.data.datamodule import DataModule
+from snowfall.data.asr_datamodule import AsrDataModule
 
 
-class LibriSpeechDataModule(DataModule):
+class LibriSpeechAsrDataModule(AsrDataModule):
+    """
+    LibriSpeech ASR data module. Can be used for 100h subset (``--full-libri false``) or full 960h set.
+    The train and valid cuts for standard Libri splits are concatenated into a single CutSet/DataLoader.
+    """
+
     def add_arguments(self, parser: argparse.ArgumentParser):
-        group = parser.add_argument_group(
-            title='Data related options',
-            description='These options are used for the preparation of PyTorch DataLoaders '
-                        'from Lhotse CutSet\'s -- they control the effective batch sizes, '
-                        'sampling strategies, applied data augmentations, etc.'
-        )
-        group.add_argument(
-            '--max-duration',
-            type=int,
-            default=500.0,
-            help="Maximum pooled recordings duration (seconds) in a single batch.")
-        group.add_argument(
-            '--bucketing_sampler',
-            type=str2bool,
-            default=False,
-            help='When enabled, the batches will come from buckets of '
-                 'similar duration (saves padding frames).')
-        group.add_argument(
-            '--num-buckets',
-            type=int,
-            default=30,
-            help='The number of buckets for the BucketingSampler'
-                 '(you might want to increase it for larger datasets).')
-        group.add_argument(
-            '--concatenate-cuts',
-            type=str2bool,
-            default=True,
-            help='When enabled, utterances (cuts) will be concatenated '
-                 'to minimize the amount of padding.')
-        group.add_argument(
-            '--duration-factor',
-            type=float,
-            default=1.0,
-            help='Determines the maximum duration of a concatenated cut '
-                 'relative to the duration of the longest cut in a batch.')
-        group.add_argument(
-            '--gap',
-            type=float,
-            default=1.0,
-            help='The amount of padding (in seconds) inserted between concatenated cuts. '
-                 'This padding is filled with noise when noise augmentation is used.')
+        super().add_arguments(parser)
+        group = parser.add_argument_group(title='LibriSpeech specific options')
         group.add_argument(
             '--full-libri',
             type=str2bool,
-            default=False,
+            default=True,
             help='When enabled, use 960h LibriSpeech.')
-        group.add_argument(
-            '--on-the-fly-feats',
-            type=str2bool,
-            default=False,
-            help='When enabled, use on-the-fly cut mixing and feature extraction. '
-                 'Will drop existing precomputed feature manifests if available.'
-        )
 
-    def train_dataloaders(self) -> DataLoader:
+    @lru_cache()
+    def train_cuts(self) -> CutSet:
         logging.info("About to get train cuts")
         cuts_train = load_manifest(self.args.feature_dir / 'cuts_train-clean-100.json.gz')
         if self.args.full_libri:
@@ -78,114 +35,22 @@ class LibriSpeechDataModule(DataModule):
                     load_manifest(self.args.feature_dir / 'cuts_train-clean-360.json.gz') +
                     load_manifest(self.args.feature_dir / 'cuts_train-other-500.json.gz')
             )
+        return cuts_train
 
-        logging.info("About to get Musan cuts")
-        cuts_musan = load_manifest(self.args.feature_dir / 'cuts_musan.json.gz')
-
-        logging.info("About to create train dataset")
-        transforms = [CutMix(cuts=cuts_musan, prob=0.5, snr=(10, 20))]
-        if self.args.concatenate_cuts:
-            logging.info(f'Using cut concatenation with duration factor '
-                         f'{self.args.duration_factor} and gap {self.args.gap}.')
-            # Cut concatenation should be the first transform in the list,
-            # so that if we e.g. mix noise in, it will fill the gaps between different utterances.
-            transforms = [
-                CutConcatenate(
-                    duration_factor=self.args.duration_factor,
-                    gap=self.args.gap
-                )
-             ] + transforms
-
-        input_transforms = [
-            SpecAugment(num_frame_masks=2, features_mask_size=27, num_feature_masks=2, frames_mask_size=100)
-        ]
-
-        train = K2SpeechRecognitionDataset(
-            cuts_train,
-            cut_transforms=transforms,
-            input_transforms=input_transforms
-        )
-
-        if self.args.on_the_fly_feats:
-            # NOTE: the PerturbSpeed transform should be added only if we remove it from data prep stage.
-            # # Add on-the-fly speed perturbation; since originally it would have increased epoch
-            # # size by 3, we will apply prob 2/3 and use 3x more epochs.
-            # # Speed perturbation probably should come first before concatenation,
-            # # but in principle the transforms order doesn't have to be strict (e.g. could be randomized)
-            # transforms = [PerturbSpeed(factors=[0.9, 1.1], p=2 / 3)] + transforms
-            # Drop feats to be on the safe side.
-            cuts_train = cuts_train.drop_features()
-            train = K2SpeechRecognitionDataset(
-                cuts=cuts_train,
-                cut_transforms=transforms,
-                input_strategy=OnTheFlyFeatures(Fbank(FbankConfig(num_mel_bins=80))),
-                input_transforms=input_transforms
-            )
-
-        if self.args.bucketing_sampler:
-            logging.info('Using BucketingSampler.')
-            train_sampler = BucketingSampler(
-                cuts_train,
-                max_duration=self.args.max_duration,
-                shuffle=True,
-                num_buckets=self.args.num_buckets
-            )
-        else:
-            logging.info('Using SingleCutSampler.')
-            train_sampler = SingleCutSampler(
-                cuts_train,
-                max_duration=self.args.max_duration,
-                shuffle=True,
-            )
-        logging.info("About to create train dataloader")
-        train_dl = DataLoader(
-            train,
-            sampler=train_sampler,
-            batch_size=None,
-            num_workers=4,
-        )
-        return train_dl
-
-    def valid_dataloaders(self) -> DataLoader:
+    @lru_cache()
+    def valid_cuts(self) -> CutSet:
         logging.info("About to get dev cuts")
-        cuts_dev = (
+        cuts_valid = (
                 load_manifest(self.feature_dir / 'cuts_dev-clean.json.gz') +
                 load_manifest(self.feature_dir / 'cuts_dev-other.json.gz')
         )
+        return cuts_valid
 
-        logging.info("About to create dev dataset")
-        if self.args.on_the_fly_feats:
-            cuts_dev = cuts_dev.drop_features()
-            validate = K2SpeechRecognitionDataset(
-                cuts_dev.drop_features(),
-                input_strategy=OnTheFlyFeatures(Fbank(FbankConfig(num_mel_bins=80)))
-            )
-        else:
-            validate = K2SpeechRecognitionDataset(cuts_dev)
-        valid_sampler = SingleCutSampler(
-            cuts_dev,
-            max_duration=self.args.max_duration,
-        )
-        logging.info("About to create dev dataloader")
-        valid_dl = DataLoader(
-            validate,
-            sampler=valid_sampler,
-            batch_size=None,
-            num_workers=1
-        )
-        return valid_dl
-
-    def test_dataloaders(self) -> List[DataLoader]:
+    @lru_cache()
+    def test_cuts(self) -> List[CutSet]:
         test_sets = ['test-clean', 'test-other']
+        cuts = []
         for test_set in test_sets:
             logging.debug("About to get test cuts")
-            cuts_test = load_manifest(self.args.feature_dir / f'cuts_{test_set}.json.gz')
-            logging.debug("About to create test dataset")
-            test = K2SpeechRecognitionDataset(
-                cuts_test,
-                input_strategy=OnTheFlyFeatures(Fbank(FbankConfig(num_mel_bins=80)))
-            )
-            sampler = SingleCutSampler(cuts_test, max_duration=self.args.max_duration)
-            logging.debug("About to create test dataloader")
-            test_dl = DataLoader(test, batch_size=None, sampler=sampler, num_workers=1)
-            yield test_dl
+            cuts.append(load_manifest(self.args.feature_dir / f'cuts_{test_set}.json.gz'))
+        return cuts

--- a/snowfall/data/librispeech.py
+++ b/snowfall/data/librispeech.py
@@ -16,7 +16,8 @@ class LibriSpeechAsrDataModule(AsrDataModule):
     The train and valid cuts for standard Libri splits are concatenated into a single CutSet/DataLoader.
     """
 
-    def add_arguments(self, parser: argparse.ArgumentParser):
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser):
         super().add_arguments(parser)
         group = parser.add_argument_group(title='LibriSpeech specific options')
         group.add_argument(


### PR DESCRIPTION
Guys, take a look and let me know if you think this makes sense. I thought about this a bit and I think there are four main "modules" in snowfall:
- data pipeline (cuts/augmentation/dataloaders)
- models (e.g. conformer and its settings)
- training/testing loop structure
- loss functions (e.g. CTC, MMI, others and how they interact with lexicon/LM graphs)

I think they are 80% orthogonal and the 20% that interleaves is probably the tricky part to structure this in the right way. I think each of them should be structured into some sort of module that registers arguments in an `argparse.ArgumentParser`, and we can use `jsonargparse` later to keep the configuration in YAML files (this seems to work fine in ESPnet, it's also a bit similar to how Kaldi did it).

This PR is dealing with the data pipeline. I'm trying to put LibriSpeech and Aishell into a similar structure -- both recipes actually share 95% of the cuts-related code and another one that I started preparing for BABEL languages also seems to head in this direction.

The design is loosely inspired by [PytorchLightning's DataModules](https://pytorch-lightning.readthedocs.io/en/latest/extensions/datamodules.html) -- if we ever decide that we want to use Lightning it's probably easy to adopt it fully. I suggest first looking at `DataModule`, then `AsrDataModule`, then `LibriSpeechAsrDataModule`/`AishellAsrDataModule`, and then at the mmi_attention training/decoding scripts.

WDYT?