### PR TITLE
Fix transformer/conformer bugs when normalize_before is false

### DIFF
--- a/snowfall/models/conformer.py
+++ b/snowfall/models/conformer.py
@@ -175,8 +175,9 @@ class ConformerEncoderLayer(nn.Module):
         src = residual + self.ff_scale * self.dropout(self.feed_forward(src))
         if not self.normalize_before:
             src = self.norm_ff(src)
-
-        src = self.norm_final(src)
+        
+        if self.normalize_before:
+            src = self.norm_final(src)
 
         return src
 

--- a/snowfall/models/transformer.py
+++ b/snowfall/models/transformer.py
@@ -45,7 +45,7 @@ class Transformer(AcousticModel):
                               Conv2dSubsampling(num_features, d_model))
         self.encoder_pos = PositionalEncoding(d_model, dropout)
 
-        encoder_layer = TransformerEncoderLayer(d_model, nhead, dim_feedforward, dropout)
+        encoder_layer = TransformerEncoderLayer(d_model, nhead, dim_feedforward, dropout, normalize_before=normalize_before)
 
         if normalize_before:
             encoder_norm = nn.LayerNorm(d_model)
@@ -65,7 +65,7 @@ class Transformer(AcousticModel):
             self.decoder_embed = nn.Embedding(self.decoder_num_class, d_model)
             self.decoder_pos = PositionalEncoding(d_model, dropout)
 
-            decoder_layer = TransformerDecoderLayer(d_model, nhead, dim_feedforward, dropout)
+            decoder_layer = TransformerDecoderLayer(d_model, nhead, dim_feedforward, dropout, normalize_before=normalize_before)
 
             if normalize_before:
                 decoder_norm = nn.LayerNorm(d_model)


### PR DESCRIPTION
Fix two transformer/conformer bugs when normalize_before is false. 
- In transformer, argument `normalize_before` is not passed to encoder/decoder layers
- In conformer, when set `normalize_before = False`, there is a repeated LayerNorm.

Thanks to review from @csukuangfj !