### PR TITLE
[WIP] Implement 2nd pass training using 1-best decoding results from the 1st pass network

### DIFF
--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_train_2nd.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_train_2nd.py
@@ -1,0 +1,641 @@
+#!/usr/bin/env python3
+
+# Copyright (c)  2020  Xiaomi Corporation (authors: Daniel Povey
+#                                                   Haowen Qiu
+#                                                   Fangjun Kuang)
+#                2021  University of Chinese Academy of Sciences (author: Han Zhu)
+# Apache 2.0
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, Optional
+
+import k2
+import numpy as np
+import torch
+import torch.distributed as dist
+import torch.multiprocessing as mp
+from torch import nn
+from torch.cuda.amp import GradScaler, autocast
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.nn.utils import clip_grad_value_
+from torch.utils.data import DataLoader
+from torch.utils.tensorboard import SummaryWriter
+
+from lhotse.utils import fix_random_seed, nullcontext
+from snowfall.common import describe, str2bool
+from snowfall.common import load_checkpoint, save_checkpoint
+from snowfall.common import save_training_info
+from snowfall.common import setup_logger
+from snowfall.data.librispeech import LibriSpeechAsrDataModule
+from snowfall.dist import cleanup_dist
+from snowfall.dist import setup_dist
+from snowfall.lexicon import Lexicon
+from snowfall.models import AcousticModel
+from snowfall.models.conformer import Conformer
+from snowfall.models.tdnn_lstm import TdnnLstm1b  # alignment model
+from snowfall.models.transformer import Noam, Transformer
+from snowfall.objectives import LFMMILoss, encode_supervisions
+from snowfall.training.diagnostics import measure_gradient_norms, optim_step_and_measure_param_change
+from snowfall.training.mmi_graph import MmiTrainingGraphCompiler
+from snowfall.training.mmi_graph import create_bigram_phone_lm
+
+
+def get_objf(batch: Dict,
+             model: AcousticModel,
+             ali_model: Optional[AcousticModel],
+             P: k2.Fsa,
+             device: torch.device,
+             graph_compiler: MmiTrainingGraphCompiler,
+             is_training: bool,
+             is_update: bool,
+             accum_grad: int = 1,
+             den_scale: float = 1.0,
+             att_rate: float = 0.0,
+             tb_writer: Optional[SummaryWriter] = None,
+             global_batch_idx_train: Optional[int] = None,
+             optimizer: Optional[torch.optim.Optimizer] = None,
+             scaler: GradScaler = None
+             ):
+    feature = batch['inputs']
+    # at entry, feature is [N, T, C]
+    feature = feature.permute(0, 2, 1)  # now feature is [N, C, T]
+    assert feature.ndim == 3
+    feature = feature.to(device)
+
+    supervisions = batch['supervisions']
+    supervision_segments, texts = encode_supervisions(supervisions)
+
+    loss_fn = LFMMILoss(
+        graph_compiler=graph_compiler,
+        P=P,
+        den_scale=den_scale
+    )
+
+    grad_context = nullcontext if is_training else torch.no_grad
+
+    with autocast(enabled=scaler.is_enabled()), grad_context():
+        nnet_output, encoder_memory, memory_mask = model(feature, supervisions)
+        if att_rate != 0.0:
+            att_loss = model.module.decoder_forward(encoder_memory, memory_mask, supervisions, graph_compiler)
+
+        if (ali_model is not None and global_batch_idx_train is not None and
+                global_batch_idx_train * accum_grad < 4000):
+            with torch.no_grad():
+                ali_model_output = ali_model(feature)
+            # subsampling is done slightly differently, may be small length
+            # differences.
+            min_len = min(ali_model_output.shape[2], nnet_output.shape[2])
+            # scale less than one so it will be encouraged
+            # to mimic ali_model's output
+            ali_model_scale = 500.0 / (global_batch_idx_train*accum_grad + 500)
+            nnet_output = nnet_output.clone()  # or log-softmax backprop will fail.
+            nnet_output[:, :,:min_len] += ali_model_scale * ali_model_output[:, :,:min_len]
+
+        # nnet_output is [N, C, T]
+        nnet_output = nnet_output.permute(0, 2, 1)  # now nnet_output is [N, T, C]
+
+        mmi_loss, tot_frames, all_frames = loss_fn(nnet_output, texts, supervision_segments)
+
+    if is_training:
+        def maybe_log_gradients(tag: str):
+            if tb_writer is not None and global_batch_idx_train is not None and global_batch_idx_train % 200 == 0:
+                tb_writer.add_scalars(
+                    tag,
+                    measure_gradient_norms(model, norm='l1'),
+                    global_step=global_batch_idx_train
+                )
+
+        if att_rate != 0.0:
+            loss = (- (1.0 - att_rate) * mmi_loss + att_rate * att_loss) / (len(texts) * accum_grad)
+        else:
+            loss = (-mmi_loss) / (len(texts) * accum_grad)
+        scaler.scale(loss).backward()
+        if is_update:
+            maybe_log_gradients('train/grad_norms')
+            scaler.unscale_(optimizer)
+            clip_grad_value_(model.parameters(), 5.0)
+            maybe_log_gradients('train/clipped_grad_norms')
+            if tb_writer is not None and (global_batch_idx_train // accum_grad) % 200 == 0:
+                # Once in a time we will perform a more costly diagnostic
+                # to check the relative parameter change per minibatch.
+                deltas = optim_step_and_measure_param_change(model, optimizer, scaler)
+                tb_writer.add_scalars(
+                    'train/relative_param_change_per_minibatch',
+                    deltas,
+                    global_step=global_batch_idx_train
+                )
+            else:
+                scaler.step(optimizer)
+            optimizer.zero_grad()
+            scaler.update()
+
+    ans = -mmi_loss.detach().cpu().item(), tot_frames.cpu().item(
+    ), all_frames.cpu().item()
+    return ans
+
+
+def get_validation_objf(dataloader: torch.utils.data.DataLoader,
+                        model: AcousticModel,
+                        ali_model: Optional[AcousticModel],
+                        P: k2.Fsa,
+                        device: torch.device,
+                        graph_compiler: MmiTrainingGraphCompiler,
+                        scaler: GradScaler,
+                        den_scale: float = 1,
+                        ):
+    total_objf = 0.
+    total_frames = 0.  # for display only
+    total_all_frames = 0.  # all frames including those seqs that failed.
+
+    model.eval()
+
+    from torchaudio.datasets.utils import bg_iterator
+    for batch_idx, batch in enumerate(bg_iterator(dataloader, 2)):
+        objf, frames, all_frames = get_objf(
+            batch=batch,
+            model=model,
+            ali_model=ali_model,
+            P=P,
+            device=device,
+            graph_compiler=graph_compiler,
+            is_training=False,
+            is_update=False,
+            den_scale=den_scale,
+            scaler=scaler
+        )
+        total_objf += objf
+        total_frames += frames
+        total_all_frames += all_frames
+
+    return total_objf, total_frames, total_all_frames
+
+
+def train_one_epoch(dataloader: torch.utils.data.DataLoader,
+                    valid_dataloader: torch.utils.data.DataLoader,
+                    model: AcousticModel,
+                    ali_model: Optional[AcousticModel],
+                    P: k2.Fsa,
+                    device: torch.device,
+                    graph_compiler: MmiTrainingGraphCompiler,
+                    optimizer: torch.optim.Optimizer,
+                    accum_grad: int,
+                    den_scale: float,
+                    att_rate: float,
+                    current_epoch: int,
+                    tb_writer: SummaryWriter,
+                    num_epochs: int,
+                    global_batch_idx_train: int,
+                    world_size: int,
+                    scaler: GradScaler
+                    ):
+    """One epoch training and validation.
+
+    Args:
+        dataloader: Training dataloader
+        valid_dataloader: Validation dataloader
+        model: Acoustic model to be trained
+        P: An FSA representing the bigram phone LM
+        device: Training device, torch.device("cpu") or torch.device("cuda", device_id)
+        graph_compiler: MMI training graph compiler
+        optimizer: Training optimizer
+        accum_grad: Number of gradient accumulation
+        den_scale: Denominator scale in mmi loss
+        att_rate: Attention loss rate, final loss is att_rate * att_loss + (1-att_rate) * other_loss
+        current_epoch: current training epoch, for logging only
+        tb_writer: tensorboard SummaryWriter
+        num_epochs: total number of training epochs, for logging only
+        global_batch_idx_train: global training batch index before this epoch, for logging only
+
+    Returns:
+        A tuple of 3 scalar:  (total_objf / total_frames, valid_average_objf, global_batch_idx_train)
+        - `total_objf / total_frames` is the average training loss
+        - `valid_average_objf` is the average validation loss
+        - `global_batch_idx_train` is the global training batch index after this epoch
+    """
+    total_objf, total_frames, total_all_frames = 0., 0., 0.
+    valid_average_objf = float('inf')
+    time_waiting_for_batch = 0
+    forward_count = 0
+    prev_timestamp = datetime.now()
+
+    model.train()
+    for batch_idx, batch in enumerate(dataloader):
+        forward_count += 1
+        if forward_count == accum_grad:
+            is_update = True
+            forward_count = 0
+        else:
+            is_update = False
+
+        global_batch_idx_train += 1
+        timestamp = datetime.now()
+        time_waiting_for_batch += (timestamp - prev_timestamp).total_seconds()
+
+        if forward_count == 1 or accum_grad == 1:
+            P.set_scores_stochastic_(model.module.P_scores)
+            assert P.requires_grad is True
+
+        curr_batch_objf, curr_batch_frames, curr_batch_all_frames = get_objf(
+            batch=batch,
+            model=model,
+            ali_model=ali_model,
+            P=P,
+            device=device,
+            graph_compiler=graph_compiler,
+            is_training=True,
+            is_update=is_update,
+            accum_grad=accum_grad,
+            den_scale=den_scale,
+            att_rate=att_rate,
+            tb_writer=tb_writer,
+            global_batch_idx_train=global_batch_idx_train,
+            optimizer=optimizer,
+            scaler=scaler
+        )
+
+        total_objf += curr_batch_objf
+        total_frames += curr_batch_frames
+        total_all_frames += curr_batch_all_frames
+
+        if batch_idx % 10 == 0:
+            logging.info(
+                'batch {}, epoch {}/{} '
+                'global average objf: {:.6f} over {} '
+                'frames ({:.1f}% kept), current batch average objf: {:.6f} over {} frames ({:.1f}% kept) '
+                'avg time waiting for batch {:.3f}s'.format(
+                    batch_idx, current_epoch, num_epochs,
+                    total_objf / total_frames, total_frames,
+                    100.0 * total_frames / total_all_frames,
+                    curr_batch_objf / (curr_batch_frames + 0.001),
+                    curr_batch_frames,
+                    100.0 * curr_batch_frames / curr_batch_all_frames,
+                    time_waiting_for_batch / max(1, batch_idx)))
+
+            if tb_writer is not None:
+                tb_writer.add_scalar('train/global_average_objf',
+                                     total_objf / total_frames, global_batch_idx_train)
+
+                tb_writer.add_scalar('train/current_batch_average_objf',
+                                     curr_batch_objf / (curr_batch_frames + 0.001),
+                                     global_batch_idx_train)
+            # if batch_idx >= 10:
+            #    print("Exiting early to get profile info")
+            #    sys.exit(0)
+
+        if batch_idx > 0 and batch_idx % 200 == 0:
+            total_valid_objf, total_valid_frames, total_valid_all_frames = get_validation_objf(
+                dataloader=valid_dataloader,
+                model=model,
+                ali_model=ali_model,
+                P=P,
+                device=device,
+                graph_compiler=graph_compiler,
+                scaler=scaler)
+            if world_size > 1:
+                s = torch.tensor([
+                    total_valid_objf, total_valid_frames,
+                    total_valid_all_frames
+                ]).to(device)
+
+                dist.all_reduce(s, op=dist.ReduceOp.SUM)
+                total_valid_objf, total_valid_frames, total_valid_all_frames = s.cpu().tolist()
+
+            valid_average_objf = total_valid_objf / total_valid_frames
+            model.train()
+            logging.info(
+                'Validation average objf: {:.6f} over {} frames ({:.1f}% kept)'
+                    .format(valid_average_objf,
+                            total_valid_frames,
+                            100.0 * total_valid_frames / total_valid_all_frames))
+
+            if tb_writer is not None:
+                tb_writer.add_scalar('train/global_valid_average_objf',
+                                     valid_average_objf,
+                                     global_batch_idx_train)
+                model.module.write_tensorboard_diagnostics(tb_writer, global_step=global_batch_idx_train)
+        prev_timestamp = datetime.now()
+    return total_objf / total_frames, valid_average_objf, global_batch_idx_train
+
+
+def get_parser():
+    parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '--world-size',
+        type=int,
+        default=1,
+        help='Number of GPUs for DDP training.')
+    parser.add_argument(
+        '--master-port',
+        type=int,
+        default=12354,
+        help='Master port to use for DDP training.')
+    parser.add_argument(
+        '--model-type',
+        type=str,
+        default="conformer",
+        choices=["transformer", "conformer"],
+        help="Model type.")
+    parser.add_argument(
+        '--num-epochs',
+        type=int,
+        default=10,
+        help="Number of training epochs.")
+    parser.add_argument(
+        '--start-epoch',
+        type=int,
+        default=0,
+        help="Number of start epoch.")
+    parser.add_argument(
+        '--warm-step',
+        type=int,
+        default=5000,
+        help='The number of warm-up steps for Noam optimizer.'
+    )
+    parser.add_argument(
+        '--accum-grad',
+        type=int,
+        default=1,
+        help="Number of gradient accumulation.")
+    parser.add_argument(
+        '--den-scale',
+        type=float,
+        default=1.0,
+        help="denominator scale in mmi loss.")
+    parser.add_argument(
+        '--att-rate',
+        type=float,
+        default=0.0,
+        help="Attention loss rate.")
+    parser.add_argument(
+        '--nhead',
+        type=int,
+        default=4,
+        help="Number of attention heads in transformer.")
+    parser.add_argument(
+        '--attention-dim',
+        type=int,
+        default=256,
+        help="Number of units in transformer attention layers.")
+    parser.add_argument(
+        '--tensorboard',
+        type=str2bool,
+        default=True,
+        help='Should various information be logged in tensorboard.'
+    )
+    parser.add_argument(
+        '--amp',
+        type=str2bool,
+        default=True,
+        help='Should we use automatic mixed precision (AMP) training.'
+    )
+    parser.add_argument(
+        '--use-ali-model',
+        type=str2bool,
+        default=True,
+        help='If true, we assume that you have run ./ctc_train.py '
+             'and you have some checkpoints inside the directory '
+             'exp-lstm-adam-ctc-musan/ .'
+             'It will use exp-lstm-adam-ctc-musan/epoch-{ali-model-epoch}.pt '
+             'as the pre-trained alignment model'
+    )
+    parser.add_argument(
+        '--ali-model-epoch',
+        type=int,
+        default=7,
+        help='If --use-ali-model is True, load '
+             'exp-lstm-adam-ctc-musan/epoch-{ali-model-epoch}.pt as the alignment model.'
+             'Used only if --use-ali-model is True.'
+    )
+    return parser
+
+
+def run(rank, world_size, args):
+    '''
+    Args:
+      rank:
+        It is a value between 0 and `world_size-1`, which is
+        passed automatically by `mp.spawn()` in :func:`main`.
+        The node with rank 0 is responsible for saving checkpoint.
+      world_size:
+        Number of GPUs for DDP training.
+      args:
+        The return value of get_parser().parse_args()
+    '''
+    model_type = args.model_type
+    start_epoch = args.start_epoch
+    num_epochs = args.num_epochs
+    accum_grad = args.accum_grad
+    den_scale = args.den_scale
+    att_rate = args.att_rate
+
+    fix_random_seed(42)
+    setup_dist(rank, world_size, args.master_port)
+
+    exp_dir = Path('exp-' + model_type + '-noam-mmi-att-musan-sa')
+    setup_logger(f'{exp_dir}/log/log-train-{rank}')
+    if args.tensorboard and rank == 0:
+        tb_writer = SummaryWriter(log_dir=f'{exp_dir}/tensorboard')
+    else:
+        tb_writer = None
+    #  tb_writer = SummaryWriter(log_dir=f'{exp_dir}/tensorboard') if args.tensorboard and rank == 0 else None
+
+    logging.info("Loading lexicon and symbol tables")
+    lang_dir = Path('data/lang_nosp')
+    lexicon = Lexicon(lang_dir)
+
+    device_id = rank
+    device = torch.device('cuda', device_id)
+
+    graph_compiler = MmiTrainingGraphCompiler(
+        lexicon=lexicon,
+        device=device,
+    )
+    phone_ids = lexicon.phone_symbols()
+    P = create_bigram_phone_lm(phone_ids)
+    P.scores = torch.zeros_like(P.scores)
+    P = P.to(device)
+
+    librispeech = LibriSpeechAsrDataModule(args)
+    train_dl = librispeech.train_dataloaders()
+    valid_dl = librispeech.valid_dataloaders()
+
+    if not torch.cuda.is_available():
+        logging.error('No GPU detected!')
+        sys.exit(-1)
+
+    logging.info("About to create model")
+
+    if att_rate != 0.0:
+        num_decoder_layers = 6
+    else:
+        num_decoder_layers = 0
+
+    if model_type == "transformer":
+        model = Transformer(
+            num_features=80,
+            nhead=args.nhead,
+            d_model=args.attention_dim,
+            num_classes=len(phone_ids) + 1,  # +1 for the blank symbol
+            subsampling_factor=4,
+            num_decoder_layers=num_decoder_layers)
+    else:
+        model = Conformer(
+            num_features=80,
+            nhead=args.nhead,
+            d_model=args.attention_dim,
+            num_classes=len(phone_ids) + 1,  # +1 for the blank symbol
+            subsampling_factor=4,
+            num_decoder_layers=num_decoder_layers)
+
+    model.P_scores = nn.Parameter(P.scores.clone(), requires_grad=True)
+
+    model.to(device)
+    describe(model)
+
+    model = DDP(model, device_ids=[rank])
+
+    # Now for the aligment model, if any
+    if args.use_ali_model:
+        ali_model = TdnnLstm1b(
+            num_features=80,
+            num_classes=len(phone_ids) + 1,  # +1 for the blank symbol
+            subsampling_factor=4)
+
+        ali_model_fname = Path(f'exp-lstm-adam-ctc-musan/epoch-{args.ali_model_epoch}.pt')
+        assert ali_model_fname.is_file(), \
+                f'ali model filename {ali_model_fname} does not exist!'
+        ali_model.load_state_dict(torch.load(ali_model_fname, map_location='cpu')['state_dict'])
+        ali_model.to(device)
+
+        ali_model.eval()
+        ali_model.requires_grad_(False)
+        logging.info(f'Use ali_model: {ali_model_fname}')
+    else:
+        ali_model = None
+        logging.info('No ali_model')
+
+    optimizer = Noam(model.parameters(),
+                     model_size=args.attention_dim,
+                     factor=1.0,
+                     warm_step=args.warm_step)
+
+    scaler = GradScaler(enabled=args.amp)
+
+    best_objf = np.inf
+    best_valid_objf = np.inf
+    best_epoch = start_epoch
+    best_model_path = os.path.join(exp_dir, 'best_model.pt')
+    best_epoch_info_filename = os.path.join(exp_dir, 'best-epoch-info')
+    global_batch_idx_train = 0  # for logging only
+
+    if start_epoch > 0:
+        model_path = os.path.join(exp_dir, 'epoch-{}.pt'.format(start_epoch - 1))
+        ckpt = load_checkpoint(filename=model_path, model=model, optimizer=optimizer, scaler=scaler)
+        best_objf = ckpt['objf']
+        best_valid_objf = ckpt['valid_objf']
+        global_batch_idx_train = ckpt['global_batch_idx_train']
+        logging.info(f"epoch = {ckpt['epoch']}, objf = {best_objf}, valid_objf = {best_valid_objf}")
+
+    for epoch in range(start_epoch, num_epochs):
+        train_dl.sampler.set_epoch(epoch)
+        curr_learning_rate = optimizer._rate
+        if tb_writer is not None:
+            tb_writer.add_scalar('train/learning_rate', curr_learning_rate, global_batch_idx_train)
+            tb_writer.add_scalar('train/epoch', epoch, global_batch_idx_train)
+
+        logging.info('epoch {}, learning rate {}'.format(epoch, curr_learning_rate))
+        objf, valid_objf, global_batch_idx_train = train_one_epoch(
+            dataloader=train_dl,
+            valid_dataloader=valid_dl,
+            model=model,
+            ali_model=ali_model,
+            P=P,
+            device=device,
+            graph_compiler=graph_compiler,
+            optimizer=optimizer,
+            accum_grad=accum_grad,
+            den_scale=den_scale,
+            att_rate=att_rate,
+            current_epoch=epoch,
+            tb_writer=tb_writer,
+            num_epochs=num_epochs,
+            global_batch_idx_train=global_batch_idx_train,
+            world_size=world_size,
+            scaler=scaler
+        )
+        # the lower, the better
+        if valid_objf < best_valid_objf:
+            best_valid_objf = valid_objf
+            best_objf = objf
+            best_epoch = epoch
+            save_checkpoint(filename=best_model_path,
+                            optimizer=None,
+                            scheduler=None,
+                            scaler=None,
+                            model=model,
+                            epoch=epoch,
+                            learning_rate=curr_learning_rate,
+                            objf=objf,
+                            valid_objf=valid_objf,
+                            global_batch_idx_train=global_batch_idx_train,
+                            local_rank=rank)
+            save_training_info(filename=best_epoch_info_filename,
+                               model_path=best_model_path,
+                               current_epoch=epoch,
+                               learning_rate=curr_learning_rate,
+                               objf=objf,
+                               best_objf=best_objf,
+                               valid_objf=valid_objf,
+                               best_valid_objf=best_valid_objf,
+                               best_epoch=best_epoch,
+                               local_rank=rank)
+
+        # we always save the model for every epoch
+        model_path = os.path.join(exp_dir, 'epoch-{}.pt'.format(epoch))
+        save_checkpoint(filename=model_path,
+                        optimizer=optimizer,
+                        scheduler=None,
+                        scaler=scaler,
+                        model=model,
+                        epoch=epoch,
+                        learning_rate=curr_learning_rate,
+                        objf=objf,
+                        valid_objf=valid_objf,
+                        global_batch_idx_train=global_batch_idx_train,
+                        local_rank=rank)
+        epoch_info_filename = os.path.join(exp_dir, 'epoch-{}-info'.format(epoch))
+        save_training_info(filename=epoch_info_filename,
+                           model_path=model_path,
+                           current_epoch=epoch,
+                           learning_rate=curr_learning_rate,
+                           objf=objf,
+                           best_objf=best_objf,
+                           valid_objf=valid_objf,
+                           best_valid_objf=best_valid_objf,
+                           best_epoch=best_epoch,
+                           local_rank=rank)
+
+    logging.warning('Done')
+    torch.distributed.barrier()
+    cleanup_dist()
+
+
+def main():
+    parser = get_parser()
+    LibriSpeechAsrDataModule.add_arguments(parser)
+    args = parser.parse_args()
+    world_size = args.world_size
+    assert world_size >= 1
+    mp.spawn(run, args=(world_size, args), nprocs=world_size, join=True)
+
+
+torch.set_num_threads(1)
+torch.set_num_interop_threads(1)
+
+if __name__ == '__main__':
+    main()

--- a/snowfall/models/second_pass_model.py
+++ b/snowfall/models/second_pass_model.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+
+# Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
+#
+import logging
+
+import torch
+import torch.nn as nn
+from snowfall.models.transformer import PositionalEncoding
+from snowfall.models.transformer import TransformerEncoderLayer
+from snowfall.models.transformer import generate_square_subsequent_mask
+
+import k2
+
+
+def _compute_padding_mask(len_per_seq: torch.Tensor):
+    '''Sequences are of different lengths in number of frames
+    and they are padded to the longest length. This function
+    returns a mask to exclude the padded positions for attention.
+
+    The returned mask is called `key_padding_mask` in PyTorch's
+    implementation of multihead attention.
+
+    Args:
+      len_per_seq:
+        A 1-D tensor of dtype torch.int32 containing the number
+        of entries per seq before padding.
+    Returns:
+      Return a bool tensor of shape (len_per_seq.shape[0], max(len_per_seq)).
+      The masked positions contain True, while non-masked positions contain
+      False.
+    '''
+    assert len_per_seq.ndim == 1
+    num_seqs = len_per_seq.shape[0]
+
+    device = len_per_seq.device
+
+    max_len = len_per_seq.max().item()
+
+    # [0, 1, 2, ..., max_len - 1]
+    seq_range = torch.arange(0, max_len, dtype=torch.int64, device=device)
+
+    # [
+    #   [0, 1, 2, ..., max_len - 1]
+    #   [0, 1, 2, ..., max_len - 1]
+    #   [0, 1, 2, ..., max_len - 1]
+    #   ...
+    # ]
+    seq_range_expanded = seq_range.unsqueeze(0).expand(num_seqs, max_len)
+
+    # [
+    #   [x]
+    #   [x]
+    #   [x]
+    #   ...
+    # ]
+    len_per_seq = len_per_seq.unsqueeze(-1)
+
+    # It counts from zero, so >= instead of > is used.
+    #
+    # Padding positions are set to True
+    mask = seq_range_expanded >= len_per_seq
+    return mask
+
+
+class SecondPassModel(nn.Module):
+    '''
+    The second pass model accepts two inputs:
+
+        - The encoder memory output of the first pass model
+        - The decoding denominator lattice of the first pass model
+
+    For each sequence in the lattice, it computes the best path of it.
+    Then the labels of the best path are extracted, which are phone IDs.
+    Therefore, for each input frame, we can get its corresponding phone
+    ID, i.e., its alignment.
+
+    The phone IDs of each best path is used as input to an encoder
+    model. The encoder model uses masked multihead attention.
+
+    The output of the encoder model is concatenated with the encoder memory
+    output from the first pass model. The concatenated result is fed into
+    a linear layer. log_softmax is called on the output of the linear layer
+    and the output of log_softmax is the output of the second pass model.
+    '''
+
+    def __init__(
+            self,
+            max_phone_id: int,
+            d_model: int = 256,
+            dropout: float = 0.1,
+            nhead: int = 4,
+            dim_feedforward: int = 2048,
+            num_encoder_layers: int = 6,
+    ):
+        super().__init__()
+        normalize_before = True  # True to use pre_LayerNorm
+
+        num_classes = max_phone_id + 1  # +1 for the blank symbol
+
+        self.encoder_embed = nn.Embedding(num_classes, d_model)
+
+        self.encoder_pos = PositionalEncoding(d_model, dropout)
+
+        encoder_layer = TransformerEncoderLayer(
+            d_model=d_model,
+            nhead=nhead,
+            dim_feedforward=dim_feedforward,
+            dropout=dropout)
+
+        if normalize_before:
+            encoder_norm = nn.LayerNorm(d_model)
+        else:
+            encoder_norm = None
+
+        self.encoder = nn.TransformerEncoder(encoder_layer=encoder_layer,
+                                             num_layers=num_encoder_layers,
+                                             norm=encoder_norm)
+
+        # *2 because we concatenate the outputs of the two encoders from the first
+        # pass and the second pass model
+        self.output_linear = nn.Linear(d_model * 2, num_classes)
+
+    def forward(self, encoder_memory: torch.Tensor, den_lats: k2.Fsa,
+                supervision_segments: torch.Tensor):
+        '''
+        Args:
+          encoder_memory:
+            The output of the first network before applying log-softmax.
+            If you're using Transformer/Conformer, it is the encoder output.
+            Its shape is (T, batch_size, d_model)
+        '''
+        debug = True
+        device = encoder_memory.device
+
+        # Get the best path of each sequence. Only the labels of each path
+        # are used in the following code. 0s in labels are not removed.
+        best_paths = k2.shortest_path(den_lats, use_double_scores=True)
+
+        # Note that len_per_seq does not count -1
+        len_per_seq = supervision_segments[:, 2].to(device)
+
+        if debug:
+            # offset indicates the arc start index of each seq
+            offset = k2.index(best_paths.arcs.row_splits(2),
+                              best_paths.arcs.row_splits(1))
+
+            # number of phones per seq.
+            # minus 1 to exclude the label -1
+            expected_len_per_seq = offset[1:] - offset[:-1] - 1
+
+            assert torch.all(torch.eq(len_per_seq, expected_len_per_seq))
+
+        # Note: `phones` also contains -1, for the arcs entering the final state
+        phones = best_paths.labels.clone()
+
+        # remove label -1
+        phones = phones[phones != -1]
+
+        # torch.split requires a tuple/list for sizes, so we use tolist() here.
+        phones_per_seq = torch.split(phones, len_per_seq.tolist())
+
+        # default padding value is 0
+        padded_phones = nn.utils.rnn.pad_sequence(phones_per_seq,
+                                                  batch_first=True)
+        # padded_phones is of shape (num_seqs, T)
+        # encoder_memory is of shape (T, num_batches, F)
+
+        # Number of frames T should be equal
+        assert padded_phones.shape[1] == encoder_memory.shape[0]
+        # Caution: number of seqs is not necessarily equal to number of batches
+        #  assert padded_phones.shape[0] == encoder_memory.shape[1]
+
+        encoder_memory = encoder_memory.permute(1, 0, 2)
+        # Now encoder_memory is (num_batches, T, F)
+
+        acoustic_out = []
+        for segment in supervision_segments.tolist():
+            batch_idx, start, duration = segment
+            end = start + duration
+            acoustic_tensor = encoder_memory[batch_idx, start:end]
+            acoustic_out.append(acoustic_tensor)
+
+        padded_acoustics = nn.utils.rnn.pad_sequence(acoustic_out,
+                                                     batch_first=True)
+        # padded_acoustics is of shape (num_seqs, T, F)
+
+        x2 = self.encoder_embed(padded_phones.long())
+        # x2 is (num_seqs, T, F)
+        x2 = self.encoder_pos(x2)
+
+        assert x2.shape == padded_acoustics.shape
+
+        # (B, T, F) -> (T, B, F)
+        x2 = x2.permute(1, 0, 2)
+
+        # compute two masks
+        # (1) padding_mask
+        # (2) src_mask for masked self-attention
+
+        key_padding_mask = _compute_padding_mask(len_per_seq)
+        # key_padding_mask is of shape (B, T)
+
+        attn_mask = generate_square_subsequent_mask(x2.shape[0]).to(device)
+        # attn_mask is of shape (T, T)
+
+        x2 = self.encoder(src=x2,
+                          mask=attn_mask,
+                          src_key_padding_mask=key_padding_mask)
+
+        # x2 is (T, B, F)
+
+        x2 = x2.permute(1, 0, 2)
+
+        # now x2 is (B, T, F)
+
+        x_concat = torch.cat((padded_acoustics, x2), dim=-1)
+
+        out = self.output_linear(x_concat)
+
+        out = nn.functional.log_softmax(out, dim=2)  # (num_seqs, T, F)
+
+        return out
+
+
+def _test_compute_padding_mask():
+    len_per_seq = torch.tensor([3, 5, 1, 2, 4])
+    mask = _compute_padding_mask(len_per_seq)
+    expected_mask = torch.tensor([
+        [False, False, False, True, True],
+        [False, False, False, False, False],
+        [False, True, True, True, True],
+        [False, False, True, True, True],
+        [False, False, False, False, True],
+    ])
+    assert torch.all(torch.eq(mask, expected_mask))
+
+
+if __name__ == '__main__':
+    _test_compute_padding_mask()

--- a/snowfall/objectives/common.py
+++ b/snowfall/objectives/common.py
@@ -3,7 +3,6 @@ import torch
 from torch import Tensor
 from typing import Dict, List, Tuple
 
-
 def encode_supervisions(supervisions: Dict[str, Tensor]) -> Tuple[Tensor, List[str]]:
     """
     Encodes Lhotse's ``batch["supervisions"]`` dict into a pair of torch Tensor,
@@ -24,11 +23,13 @@ def encode_supervisions(supervisions: Dict[str, Tensor]) -> Tuple[Tensor, List[s
          (((supervisions['num_frames'] - 1) // 2 - 1) // 2)),
         1
     ).to(torch.int32)
+
     supervision_segments = torch.clamp(supervision_segments, min=0)
     indices = torch.argsort(supervision_segments[:, 2], descending=True)
     supervision_segments = supervision_segments[indices]
     texts = supervisions['text']
     texts = [texts[idx] for idx in indices]
+
     return supervision_segments, texts
 
 
@@ -55,4 +56,4 @@ def get_tot_objf_and_num_frames(
     finite_indexes = torch.nonzero(mask).squeeze(1)
     ok_frames = frames_per_seq[finite_indexes].sum()
     all_frames = frames_per_seq.sum()
-    return tot_scores[finite_indexes].sum(), ok_frames, all_frames
+    return tot_scores[finite_indexes].sum(), ok_frames.item(), all_frames.item()

--- a/snowfall/objectives/mmi.py
+++ b/snowfall/objectives/mmi.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 import torch
 from torch import nn
@@ -15,6 +15,7 @@ class LFMMILoss(nn.Module):
 
     TODO: more detailed description
     """
+
     def __init__(
             self,
             graph_compiler: MmiTrainingGraphCompiler,
@@ -26,12 +27,46 @@ class LFMMILoss(nn.Module):
         self.P = P
         self.den_scale = den_scale
 
-    def forward(
-            self,
-            nnet_output: torch.Tensor,
-            texts: List,
-            supervision_segments: torch.Tensor
-    ) -> Tuple[torch.Tensor, int, int]:
+    def forward(self,
+                nnet_output: torch.Tensor,
+                texts: List[str],
+                supervision_segments: torch.Tensor,
+                ret_den_lats: bool = False
+               ) -> Tuple[torch.Tensor, int, int, Optional[k2.Fsa]]:
+        '''
+        Args:
+          nnet_output:
+            A 3-D tensor of shape (N, T, F). It is passed to
+            :func:`k2.DenseFsaVec`, so it represents log_probs,
+            from `log_softmax()`.
+          texts:
+            A list of str. Each list item contains a transcript.
+            A transcript consists of space(s) separated words.
+            An example transcript looks like 'hello snowfall'.
+            An example texts is given below:
+
+                ['hello k2', 'hello snowfall']
+
+          supervision_segments:
+            A 2-D tensor that will be passed to :func:`k2.DenseFsaVec`.
+            See :func:`k2.DenseFsaVec` for its format.
+          ret_den_lats:
+            True to also return the resulting denominator lattice.
+        Returns:
+          Return a tuple containing 6 entries:
+
+            - A tensor with only one element containing the loss
+
+            - Number of frames that contributes to the returned loss.
+              Note that frames of sequences that result in an infinity
+              loss are not counted.
+
+            - Number of frames used in the computation.
+
+            - The denominator lattice if ret_den_lats is True.
+              Otherwise, it is None.
+            -
+        '''
         num_graphs, den_graphs = self.graph_compiler.compile(
             texts, self.P, replicate_den=False)
 
@@ -49,13 +84,14 @@ class LFMMILoss(nn.Module):
         #
         # The following converts den_graphs.aux_labels
         # from torch.Tensor to k2.RaggedInt so that
-        # we can use k2.append() later
+        # we can use k2.cat() later
         den_graphs.convert_attr_to_ragged_(name='aux_labels')
 
         num_den_graphs = k2.cat([num_graphs, den_graphs])
 
         # NOTE: The a_to_b_map in k2.intersect_dense must be sorted
-        # so the following reorders num_den_graphs.
+        # so the following reorders num_den_graphs. It also replicates
+        # den_graphs.
 
         # [0, 1, 2, ... ]
         num_graphs_indexes = torch.arange(num_fsas, dtype=torch.int32)
@@ -66,9 +102,13 @@ class LFMMILoss(nn.Module):
 
         # [0, num_fsas, 1, num_fsas, 2, num_fsas, ... ]
         num_den_graphs_indexes = torch.stack(
-            [num_graphs_indexes, den_graphs_indexes]).t().reshape(-1).to(device)
+            [num_graphs_indexes,
+             den_graphs_indexes]).t().reshape(-1).to(device)
 
-        num_den_reordered_graphs = k2.index(num_den_graphs, num_den_graphs_indexes)
+        num_den_reordered_graphs = k2.index(num_den_graphs,
+                                            num_den_graphs_indexes)
+        # Now num_den_reordered_graphs contains
+        # [num_graph0, den_graph0, num_graph1, den_graph1, ... ]
 
         # [[0, 1, 2, ...]]
         a_to_b_map = torch.arange(num_fsas, dtype=torch.int32).reshape(1, -1)
@@ -80,6 +120,8 @@ class LFMMILoss(nn.Module):
                                           dense_fsa_vec,
                                           output_beam=10.0,
                                           a_to_b_map=a_to_b_map)
+        # num_den_lats contains
+        # [num_lats0, den_lats0, num_lats1, den_lats1, ... ]
 
         num_den_tot_scores = num_den_lats.get_tot_scores(
             log_semiring=True, use_double_scores=True)
@@ -89,7 +131,22 @@ class LFMMILoss(nn.Module):
 
         tot_scores = num_tot_scores - self.den_scale * den_tot_scores
         tot_score, tot_frames, all_frames = get_tot_objf_and_num_frames(
-            tot_scores,
-            supervision_segments[:, 2]
-        )
-        return tot_score, tot_frames, all_frames
+            tot_scores, supervision_segments[:, 2])
+        if ret_den_lats:
+            # [1, 3, 5, ... ]
+            den_lats_indexes = torch.arange(start=1,
+                                            end=(2 * num_fsas),
+                                            step=2,
+                                            dtype=torch.int32,
+                                            device=device)
+            with torch.no_grad():
+                den_lats = k2.index(num_den_lats, den_lats_indexes)
+
+            assert den_lats.requires_grad is False
+        else:
+            den_lats = None
+            num_den_reordered_graphs = None
+            a_to_b_map = None
+
+        # TODO(fangjun): return a dict
+        return tot_score, tot_frames, all_frames, den_lats, num_den_reordered_graphs, a_to_b_map

--- a/snowfall/training/mmi_graph.py
+++ b/snowfall/training/mmi_graph.py
@@ -83,6 +83,8 @@ class MmiTrainingGraphCompiler(object):
 
         self.ctc_topo_inv = k2.arc_sort(ctc_topo.invert_())
 
+        self.max_phone_id = max(phone_symbols)
+
     def compile(self,
                 texts: Iterable[str],
                 P: k2.Fsa,


### PR DESCRIPTION
It implements https://github.com/k2-fsa/snowfall/pull/106#issuecomment-803796177

> BTW, since it seems this is hard to get to work, if you feel like it you could work on a simpler idea.
In training time we'd take the best-path alignment and using some kind of RNN or masked attention
we'd predict the next label in that best-path. (We'd probably take in the output of the 1st network
as an input to that). The sequence length here is the same as the original sequence length.
In test time the way this would work at least initially, is we'd run this on n-best lists obtained from the
1st-pass decoding and use the scores to decide which of the n-best paths to keep. There are more accurate
decoding methods we could look into later.

---

The training objf is decreasing and seems to be converging. Will post the decoding results later.