### PR TITLE
Support using k2.intersect_dense_pruned in computing LF-MMI loss.

### DIFF
--- a/egs/librispeech/asr/simple_v1/run.sh
+++ b/egs/librispeech/asr/simple_v1/run.sh
@@ -61,19 +61,35 @@ if [ $stage -le 5 ]; then
   python3 ./prepare.py
 fi
 
+
+# Normally, you should stop here and run the training script manually.
+# stage 1 to 5 need only to be run once.
+#
+# exit 0
+
 if [ $stage -le 6 ]; then
   # python3 ./train.py # ctc training
   # python3 ./mmi_bigram_train.py # ctc training + bigram phone LM
-  #  python3 ./mmi_mbr_train.py
+  # python3 ./mmi_mbr_train.py
+
+  # python3 ./mmi_att_transformer_train.py --help
+
+  # To use multi-gpu training, use
+  # export CUDA_VISIBLE_DEVICES="0,1"
+  # python3 ./mmi_att_transformer_train.py --world-size=2
+
+  # single gpu training
+  python3 ./mmi_att_transformer_train.py
 
   # Single node, multi-GPU training
   # Adapting to a multi-node scenario should be straightforward.
-  ngpus=2
-  python3 -m torch.distributed.launch --nproc_per_node=$ngpus ./mmi_bigram_train.py --world_size $ngpus
+  # ngpus=2
+  # python3 -m torch.distributed.launch --nproc_per_node=$ngpus ./mmi_bigram_train.py --world_size $ngpus
 fi
 
 if [ $stage -le 7 ]; then
   # python3 ./decode.py # ctc decoding
-  python3 ./mmi_bigram_decode.py --epoch 9
+  # python3 ./mmi_bigram_decode.py --epoch 9
   #  python3 ./mmi_mbr_decode.py
+  python3 ./mmi_att_transformer_decode.py
 fi

--- a/snowfall/objectives/mmi.py
+++ b/snowfall/objectives/mmi.py
@@ -9,87 +9,219 @@ from snowfall.objectives.common import get_tot_objf_and_num_frames
 from snowfall.training.mmi_graph import MmiTrainingGraphCompiler
 
 
+def _compute_mmi_loss_exact_optimized(
+        nnet_output: torch.Tensor,
+        texts: List[str],
+        supervision_segments: torch.Tensor,
+        graph_compiler: MmiTrainingGraphCompiler,
+        P: k2.Fsa,
+        den_scale: float = 1.0
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    '''
+    The function name contains `exact`, which means it uses a version of
+    intersection without pruning.
+
+    `optimized` in the function name means this function is optimized
+    in that it calls k2.intersect_dense only once
+
+    Note:
+      It is faster at the cost of using more memory.
+
+    Args:
+      nnet_output:
+        A 3-D tensor of shape [N, T, C]
+      texts:
+        The transcript. Each element consists of space(s) separated words.
+      supervision_segments:
+        A 2-D tensor that will be passed to :func:`k2.DenseFsaVec`.
+      graph_compiler:
+        Used to build num_graphs and den_graphs
+      P:
+        Represents a bigram Fsa.
+      den_scale:
+        The scale applied to the denominator tot_scores.
+    '''
+    num_graphs, den_graphs = graph_compiler.compile(texts,
+                                                    P,
+                                                    replicate_den=False)
+
+    dense_fsa_vec = k2.DenseFsaVec(nnet_output, supervision_segments)
+
+    device = num_graphs.device
+
+    num_fsas = num_graphs.shape[0]
+    assert dense_fsa_vec.dim0() == num_fsas
+
+    assert den_graphs.shape[0] == 1
+
+    # the aux_labels of num_graphs is k2.RaggedInt
+    # but it is torch.Tensor for den_graphs.
+    #
+    # The following converts den_graphs.aux_labels
+    # from torch.Tensor to k2.RaggedInt so that
+    # we can use k2.append() later
+    den_graphs.convert_attr_to_ragged_(name='aux_labels')
+
+    # The motivation to concatenate num_graphs and den_graphs
+    # is to reduce the number of calls to k2.intersect_dense.
+    num_den_graphs = k2.cat([num_graphs, den_graphs])
+
+    # NOTE: The a_to_b_map in k2.intersect_dense must be sorted
+    # so the following reorders num_den_graphs.
+    #
+    # The following code computes a_to_b_map
+
+    # [0, 1, 2, ... ]
+    num_graphs_indexes = torch.arange(num_fsas, dtype=torch.int32)
+
+    # [num_fsas, num_fsas, num_fsas, ... ]
+    den_graphs_indexes = torch.tensor([num_fsas] * num_fsas, dtype=torch.int32)
+
+    # [0, num_fsas, 1, num_fsas, 2, num_fsas, ... ]
+    num_den_graphs_indexes = torch.stack(
+        [num_graphs_indexes, den_graphs_indexes]).t().reshape(-1).to(device)
+
+    num_den_reordered_graphs = k2.index(num_den_graphs, num_den_graphs_indexes)
+
+    # [[0, 1, 2, ...]]
+    a_to_b_map = torch.arange(num_fsas, dtype=torch.int32).reshape(1, -1)
+
+    # [[0, 1, 2, ...]] -> [0, 0, 1, 1, 2, 2, ... ]
+    a_to_b_map = a_to_b_map.repeat(2, 1).t().reshape(-1).to(device)
+
+    num_den_lats = k2.intersect_dense(num_den_reordered_graphs,
+                                      dense_fsa_vec,
+                                      output_beam=10.0,
+                                      a_to_b_map=a_to_b_map)
+
+    num_den_tot_scores = num_den_lats.get_tot_scores(log_semiring=True,
+                                                     use_double_scores=True)
+
+    num_tot_scores = num_den_tot_scores[::2]
+    den_tot_scores = num_den_tot_scores[1::2]
+
+    tot_scores = num_tot_scores - den_scale * den_tot_scores
+    tot_score, tot_frames, all_frames = get_tot_objf_and_num_frames(
+        tot_scores, supervision_segments[:, 2])
+    return tot_score, tot_frames, all_frames
+
+
+def _compute_mmi_loss_exact_non_optimized(
+        nnet_output: torch.Tensor,
+        texts: List[str],
+        supervision_segments: torch.Tensor,
+        graph_compiler: MmiTrainingGraphCompiler,
+        P: k2.Fsa,
+        den_scale: float = 1.0
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    '''
+    See :func:`_compute_mmi_loss_exact_optimized` for the meaning
+    of the arguments.
+
+    It's more readable, though it invokes k2.intersect_dense twice.
+
+    Note:
+      It uses less memory at the cost of speed. It is slower.
+    '''
+    num_graphs, den_graphs = graph_compiler.compile(texts,
+                                                    P,
+                                                    replicate_den=True)
+
+    dense_fsa_vec = k2.DenseFsaVec(nnet_output, supervision_segments)
+
+    num_lats = k2.intersect_dense(num_graphs, dense_fsa_vec, output_beam=10.0)
+    den_lats = k2.intersect_dense(den_graphs, dense_fsa_vec, output_beam=10.0)
+
+    num_tot_scores = num_lats.get_tot_scores(log_semiring=True,
+                                             use_double_scores=True)
+
+    den_tot_scores = den_lats.get_tot_scores(log_semiring=True,
+                                             use_double_scores=True)
+
+    tot_scores = num_tot_scores - den_scale * den_tot_scores
+    tot_score, tot_frames, all_frames = get_tot_objf_and_num_frames(
+        tot_scores, supervision_segments[:, 2])
+    return tot_score, tot_frames, all_frames
+
+
+def _compute_mmi_loss_pruned(
+        nnet_output: torch.Tensor,
+        texts: List[str],
+        supervision_segments: torch.Tensor,
+        graph_compiler: MmiTrainingGraphCompiler,
+        P: k2.Fsa,
+        den_scale: float = 1.0
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    '''
+    See :func:`_compute_mmi_loss_exact_optimized` for the meaning
+    of the arguments.
+
+    `pruned` means it uses k2.intersect_dense_pruned
+
+    Note:
+      It uses the least amount of memory, but the loss is not exact due
+      to pruning.
+    '''
+    num_graphs, den_graphs = graph_compiler.compile(texts,
+                                                    P,
+                                                    replicate_den=False)
+    dense_fsa_vec = k2.DenseFsaVec(nnet_output, supervision_segments)
+
+    num_lats = k2.intersect_dense(num_graphs, dense_fsa_vec, output_beam=10.0)
+
+    # the values for search_beam/output_beam/min_active_states/max_active_states
+    # are not tuned. You may want to tune them.
+    den_lats = k2.intersect_dense_pruned(den_graphs,
+                                         dense_fsa_vec,
+                                         search_beam=20.0,
+                                         output_beam=7.0,
+                                         min_active_states=30,
+                                         max_active_states=10000)
+
+    num_tot_scores = num_lats.get_tot_scores(log_semiring=True,
+                                             use_double_scores=True)
+
+    den_tot_scores = den_lats.get_tot_scores(log_semiring=True,
+                                             use_double_scores=True)
+
+    tot_scores = num_tot_scores - den_scale * den_tot_scores
+    tot_score, tot_frames, all_frames = get_tot_objf_and_num_frames(
+        tot_scores, supervision_segments[:, 2])
+    return tot_score, tot_frames, all_frames
+
+
 class LFMMILoss(nn.Module):
     """
     Computes Lattice-Free Maximum Mutual Information (LFMMI) loss.
 
     TODO: more detailed description
     """
+
     def __init__(
             self,
             graph_compiler: MmiTrainingGraphCompiler,
             P: k2.Fsa,
+            use_pruned_intersect: bool = False,
             den_scale: float = 1.0,
     ):
         super().__init__()
         self.graph_compiler = graph_compiler
         self.P = P
         self.den_scale = den_scale
+        self.use_pruned_intersect = use_pruned_intersect
 
-    def forward(
-            self,
-            nnet_output: torch.Tensor,
-            texts: List,
-            supervision_segments: torch.Tensor
-    ) -> Tuple[torch.Tensor, int, int]:
-        num_graphs, den_graphs = self.graph_compiler.compile(
-            texts, self.P, replicate_den=False)
+    def forward(self, nnet_output: torch.Tensor, texts: List[str],
+                supervision_segments: torch.Tensor
+               ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if self.use_pruned_intersect:
+            func = _compute_mmi_loss_pruned
+        else:
+            #  func = _compute_mmi_loss_exact_non_optimized
+            func = _compute_mmi_loss_exact_optimized
 
-        dense_fsa_vec = k2.DenseFsaVec(nnet_output, supervision_segments)
-
-        device = num_graphs.device
-
-        num_fsas = num_graphs.shape[0]
-        assert dense_fsa_vec.dim0() == num_fsas
-
-        assert den_graphs.shape[0] == 1
-
-        # the aux_labels of num_graphs is k2.RaggedInt
-        # but it is torch.Tensor for den_graphs.
-        #
-        # The following converts den_graphs.aux_labels
-        # from torch.Tensor to k2.RaggedInt so that
-        # we can use k2.append() later
-        den_graphs.convert_attr_to_ragged_(name='aux_labels')
-
-        num_den_graphs = k2.cat([num_graphs, den_graphs])
-
-        # NOTE: The a_to_b_map in k2.intersect_dense must be sorted
-        # so the following reorders num_den_graphs.
-
-        # [0, 1, 2, ... ]
-        num_graphs_indexes = torch.arange(num_fsas, dtype=torch.int32)
-
-        # [num_fsas, num_fsas, num_fsas, ... ]
-        den_graphs_indexes = torch.tensor([num_fsas] * num_fsas,
-                                          dtype=torch.int32)
-
-        # [0, num_fsas, 1, num_fsas, 2, num_fsas, ... ]
-        num_den_graphs_indexes = torch.stack(
-            [num_graphs_indexes, den_graphs_indexes]).t().reshape(-1).to(device)
-
-        num_den_reordered_graphs = k2.index(num_den_graphs, num_den_graphs_indexes)
-
-        # [[0, 1, 2, ...]]
-        a_to_b_map = torch.arange(num_fsas, dtype=torch.int32).reshape(1, -1)
-
-        # [[0, 1, 2, ...]] -> [0, 0, 1, 1, 2, 2, ... ]
-        a_to_b_map = a_to_b_map.repeat(2, 1).t().reshape(-1).to(device)
-
-        num_den_lats = k2.intersect_dense(num_den_reordered_graphs,
-                                          dense_fsa_vec,
-                                          output_beam=10.0,
-                                          a_to_b_map=a_to_b_map)
-
-        num_den_tot_scores = num_den_lats.get_tot_scores(
-            log_semiring=True, use_double_scores=True)
-
-        num_tot_scores = num_den_tot_scores[::2]
-        den_tot_scores = num_den_tot_scores[1::2]
-
-        tot_scores = num_tot_scores - self.den_scale * den_tot_scores
-        tot_score, tot_frames, all_frames = get_tot_objf_and_num_frames(
-            tot_scores,
-            supervision_segments[:, 2]
-        )
-        return tot_score, tot_frames, all_frames
+        return func(nnet_output=nnet_output,
+                    texts=texts,
+                    supervision_segments=supervision_segments,
+                    graph_compiler=self.graph_compiler,
+                    P=self.P,
+                    den_scale=self.den_scale)


### PR DESCRIPTION
Relates https://github.com/k2-fsa/k2/issues/739

@jarvan-Wang

Could you try this pull request?

Please add the following command-line option while running the script:
```
--use-pruned-intersect=1
```

---

From https://github.com/k2-fsa/k2/issues/739#issuecomment-843077996

> or to do the den decoding separately from the num
forward-backward with intersect_dense_pruned() which allows you to use a
single FSA instead of
multiple FSAs.  That would also be more suitable since the den graph is too
large.
Fangjun, at some point we should probably create an option in the training
code (or simply an alternative code path) which is efficient
when the den graph is inconveniently large.

An option is added to let the user make the decision whether the graph is large or not.

---

I only run the script for 100 batches and the loss is decreasing as expected, so I think it is safe to merge.