### PR TITLE
Use tropical semiring for lm_paths.get_tot_scores

### DIFF
--- a/snowfall/decoding/lm_rescore.py
+++ b/snowfall/decoding/lm_rescore.py
@@ -196,7 +196,7 @@ def rescore_with_n_best_list(lats: k2.Fsa, G: k2.Fsa, num_paths: int,
                                      b_to_a_map=b_to_a_map,
                                      sorted_match_a=True)
     lm_path_lats = k2.top_sort(k2.connect(lm_path_lats.to('cpu')).to(device))
-    lm_scores = lm_path_lats.get_tot_scores(True, True)
+    lm_scores = lm_path_lats.get_tot_scores(use_double_scores=True, log_semiring=False)
 
     ans = dict()
     for lm_scale in lm_scale_list:


### PR DESCRIPTION
See https://github.com/k2-fsa/snowfall/pull/201#discussion_r647975506

> The 2nd arg to get_tot_scores() here, representing log_semiring, should be false, because ARPA-type language models are constructed in such a way that the backoff prob is included in the direct arc. I.e. we would be double-counting if we were to sum the probabilities of the non-backoff and backoff arcs.

Change log_semiring to tropical_semiring indeed improves the WER. For the test-clean dataset, when num_paths is 100
and lm_scale=1.2, the WER decreases from 6.06 to 5.98.