### PR TITLE
[WIP] update bpe models and integrate 4-gram rescore

### DIFF
--- a/egs/librispeech/asr/simple_v1/bpe_ctc_att_conformer_decode.py
+++ b/egs/librispeech/asr/simple_v1/bpe_ctc_att_conformer_decode.py
@@ -6,83 +6,301 @@
 import argparse
 import logging
 import os
-import random
-import re
-import sys
 
+from collections import defaultdict
 from pathlib import Path
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
 from typing import Union
 
 import k2
 import numpy as np
 import torch
 
-from snowfall.data import LibriSpeechAsrDataModule
+from k2 import Fsa, SymbolTable
+
 from snowfall.common import average_checkpoint, store_transcripts
+from snowfall.common import find_first_disambig_symbol
 from snowfall.common import get_texts
 from snowfall.common import load_checkpoint
 from snowfall.common import str2bool
 from snowfall.common import write_error_stats
+from snowfall.data import LibriSpeechAsrDataModule
+from snowfall.decoding.graph import compile_HLG
+from snowfall.decoding.lm_rescore import rescore_with_n_best_list
+from snowfall.decoding.lm_rescore import rescore_with_whole_lattice
+from snowfall.models import AcousticModel
 from snowfall.models.conformer import Conformer
 from snowfall.text.numericalizer import Numericalizer
 from snowfall.training.ctc_graph import build_ctc_topo
+from snowfall.training.mmi_graph import get_phone_symbols
 
+
+def nbest_decoding(lats: k2.Fsa, num_paths: int):
+    '''
+    (Ideas of this function are from Dan)
+
+    It implements something like CTC prefix beam search using n-best lists
+
+    The basic idea is to first extra n-best paths from the given lattice,
+    build a word seqs from these paths, and compute the total scores
+    of these sequences in the log-semiring. The one with the max score
+    is used as the decoding output.
+    '''
+
+    # First, extract `num_paths` paths for each sequence.
+    # paths is a k2.RaggedInt with axes [seq][path][arc_pos]
+    paths = k2.random_paths(lats, num_paths=num_paths, use_double_scores=True)
+
+    # word_seqs is a k2.RaggedInt sharing the same shape as `paths`
+    # but it contains word IDs. Note that it also contains 0s and -1s.
+    # The last entry in each sublist is -1.
+
+    word_seqs = k2.index(lats.aux_labels, paths)
+    # Note: the above operation supports also the case when
+    # lats.aux_labels is a ragged tensor. In that case,
+    # `remove_axis=True` is used inside the pybind11 binding code,
+    # so the resulting `word_seqs` still has 3 axes, like `paths`.
+    # The 3 axes are [seq][path][word]
+
+    # Remove epsilons and -1 from word_seqs
+    word_seqs = k2.ragged.remove_values_leq(word_seqs, 0)
+
+    # Remove repeated sequences to avoid redundant computation later.
+    #
+    # Since k2.ragged.unique_sequences will reorder paths within a seq,
+    # `new2old` is a 1-D torch.Tensor mapping from the output path index
+    # to the input path index.
+    # new2old.numel() == unique_word_seqs.num_elements()
+    unique_word_seqs, _, new2old = k2.ragged.unique_sequences(
+        word_seqs, need_num_repeats=False, need_new2old_indexes=True)
+    # Note: unique_word_seqs still has the same axes as word_seqs
+
+    seq_to_path_shape = k2.ragged.get_layer(unique_word_seqs.shape(), 0)
+
+    # path_to_seq_map is a 1-D torch.Tensor.
+    # path_to_seq_map[i] is the seq to which the i-th path
+    # belongs.
+    path_to_seq_map = seq_to_path_shape.row_ids(1)
+
+    # Remove the seq axis.
+    # Now unique_word_seqs has only two axes [path][word]
+    unique_word_seqs = k2.ragged.remove_axis(unique_word_seqs, 0)
+
+    # word_fsas is an FsaVec with axes [path][state][arc]
+    word_fsas = k2.linear_fsa(unique_word_seqs)
+
+    word_fsas_with_epsilon_loops = k2.add_epsilon_self_loops(word_fsas)
+
+    # lats has phone IDs as labels and word IDs as aux_labels.
+    # inv_lats has word IDs as labels and phone IDs as aux_labels
+    inv_lats = k2.invert(lats)
+    inv_lats = k2.arc_sort(inv_lats) # no-op if inv_lats is already arc-sorted
+
+    path_lats = k2.intersect_device(inv_lats,
+                                    word_fsas_with_epsilon_loops,
+                                    b_to_a_map=path_to_seq_map,
+                                    sorted_match_a=True)
+    # path_lats has word IDs as labels and phone IDs as aux_labels
+
+    path_lats = k2.top_sort(k2.connect(path_lats.to('cpu')).to(lats.device))
+
+    tot_scores = path_lats.get_tot_scores(True, True)
+    # RaggedFloat currently supports float32 only.
+    # We may bind Ragged<double> as RaggedDouble if needed.
+    ragged_tot_scores = k2.RaggedFloat(seq_to_path_shape,
+                                       tot_scores.to(torch.float32))
+
+    argmax_indexes = k2.ragged.argmax_per_sublist(ragged_tot_scores)
+
+    # Since we invoked `k2.ragged.unique_sequences`, which reorders
+    # the index from `paths`, we use `new2old`
+    # here to convert argmax_indexes to the indexes into `paths`.
+    #
+    # Use k2.index here since argmax_indexes' dtype is torch.int32
+    best_path_indexes = k2.index(new2old, argmax_indexes)
+
+    paths_2axes = k2.ragged.remove_axis(paths, 0)
+
+    # best_paths is a k2.RaggedInt with 2 axes [path][arc_pos]
+    best_paths = k2.index(paths_2axes, best_path_indexes)
+
+    # labels is a k2.RaggedInt with 2 axes [path][phone_id]
+    # Note that it contains -1s.
+    labels = k2.index(lats.labels.contiguous(), best_paths)
+
+    labels = k2.ragged.remove_values_eq(labels, -1)
+
+    # lats.aux_labels is a k2.RaggedInt tensor with 2 axes, so
+    # aux_labels is also a k2.RaggedInt with 2 axes
+    aux_labels = k2.index(lats.aux_labels, best_paths.values())
+
+    best_path_fsas = k2.linear_fsa(labels)
+    best_path_fsas.aux_labels = aux_labels
+
+    return best_path_fsas
+def decode_one_batch(batch: Dict[str, Any],
+                     model: AcousticModel,
+                     HLG: k2.Fsa,
+                     output_beam_size: float,
+                     num_paths: int,
+                     use_whole_lattice: bool,
+                     G: Optional[k2.Fsa] = None)->Dict[str, List[List[int]]]:
+    '''
+    Decode one batch and return the result in a dict. The dict has the
+    following format:
+
+        - key: It indicates the setting used for decoding. For example,
+               if no rescoring is used, the key is the string `no_rescore`.
+               If LM rescoring is used, the key is the string `lm_scale_xxx`,
+               where `xxx` is the value of `lm_scale`. An example key is
+               `lm_scale_0.7`
+        - value: It contains the decoding result. `len(value)` equals to
+                 batch size. `value[i]` is the decoding result for the i-th
+                 utterance in the given batch.
+
+    Args:
+      batch:
+        It is the return value from iterating
+        `lhotse.dataset.K2SpeechRecognitionDataset`. See its documentation
+        for the format of the `batch`.
+      model:
+        The neural network model.
+      HLG:
+        The decoding graph.
+      output_beam_size:
+        Size of the beam for pruning.
+      use_whole_lattice:
+        If True, `G` must not be None and it will use whole lattice for
+        LM rescoring.
+        If False and if `G` is not None, then `num_paths` must be positive
+        and it will use n-best list for LM rescoring.
+      num_paths:
+        It specifies the size of `n` in n-best list decoding.
+      G:
+        The LM. If it is None, no rescoring is used.
+        Otherwise, LM rescoring is used.
+        It supports two types of LM rescoring: n-best list rescoring
+        and whole lattice rescoring.
+        `use_whole_lattice` specifies which type to use.
+
+    Returns:
+      Return the decoding result. See above description for the format of
+      the returned dict.
+    '''
+    device = HLG.device
+    feature = batch['inputs']
+    assert feature.ndim == 3
+    feature = feature.to(device)
+
+    # at entry, feature is [N, T, C]
+    feature = feature.permute(0, 2, 1)  # now feature is [N, C, T]
+
+    supervisions = batch['supervisions']
+
+    nnet_output, _, _ = model(feature, supervisions)
+    # nnet_output is [N, C, T]
+
+    nnet_output = nnet_output.permute(0, 2, 1)
+    # now nnet_output is [N, T, C]
+
+    supervision_segments = torch.stack(
+        (supervisions['sequence_idx'],
+         (((supervisions['start_frame'] - 1) // 2 - 1) // 2),
+         (((supervisions['num_frames'] - 1) // 2 - 1) // 2)),
+        1).to(torch.int32)
+
+    supervision_segments = torch.clamp(supervision_segments, min=0)
+    indices = torch.argsort(supervision_segments[:, 2], descending=True)
+    supervision_segments = supervision_segments[indices]
+
+    dense_fsa_vec = k2.DenseFsaVec(nnet_output, supervision_segments)
+
+    lattices = k2.intersect_dense_pruned(HLG, dense_fsa_vec, 20.0, output_beam_size, 30, 10000)
+
+    if G is None:
+        if num_paths > 1:
+            best_paths = nbest_decoding(lattices, num_paths)
+            key=f'no_rescore-{num_paths}'
+        else:
+            key = 'no_rescore'
+            best_paths = k2.shortest_path(lattices, use_double_scores=True)
+        hyps = get_texts(best_paths, indices)
+        return {key: hyps}
+
+    lm_scale_list = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7]
+    lm_scale_list += [0.45, 0.55, 0.65]
+    lm_scale_list += [0.8, 0.9, 1.0, 1.1, 1.2, 1.3]
+    lm_scale_list += [1.4, 1.5, 1.6, 1.7, 1.8, 1.9, 2.0]
+
+    if use_whole_lattice:
+        best_paths_dict = rescore_with_whole_lattice(lattices, G,
+                                                     lm_scale_list)
+    else:
+        best_paths_dict = rescore_with_n_best_list(lattices, G, num_paths,
+                                                   lm_scale_list)
+    # best_paths_dict is a dict
+    #  - key: lm_scale_xxx, where xxx is the value of lm_scale. An example
+    #         key is lm_scale_1.2
+    #  - value: it is the best path obtained using the corresponding lm scale
+    #           from the dict key.
+
+    ans = dict()
+    for lm_scale_str, best_paths in best_paths_dict.items():
+        hyps = get_texts(best_paths, indices)
+        ans[lm_scale_str] = hyps
+    return ans
+
+
+@torch.no_grad()
 def decode(dataloader: torch.utils.data.DataLoader,
-           model: None,
-           device: Union[str, torch.device],
-           ctc_topo: None,
-           numericalizer=None,
-           num_paths=-1,
-           output_beam_size: float=8):
+           model: AcousticModel,
+           HLG: Fsa,
+           symbols: SymbolTable,
+           num_paths: int,
+           G: k2.Fsa,
+           use_whole_lattice: bool,
+           output_beam_size: float):
     tot_num_cuts = len(dataloader.dataset.cuts)
     num_cuts = 0
-    results = []
+    results = defaultdict(list)
+    # results is a dict whose keys and values are:
+    #  - key: It indicates the lm_scale, e.g., lm_scale_1.2.
+    #         If no rescoring is used, the key is the literal string: no_rescore
+    #
+    #  - value: It is a list of tuples (ref_words, hyp_words)
     for batch_idx, batch in enumerate(dataloader):
-        assert isinstance(batch, dict), type(batch)
-        feature = batch['inputs']
-        supervisions = batch['supervisions']
-        supervision_segments = torch.stack(
-            (supervisions['sequence_idx'],
-             (((supervisions['start_frame'] - 1) // 2 - 1) // 2),
-             (((supervisions['num_frames'] - 1) // 2 - 1) // 2)), 1).to(torch.int32)
-        supervision_segments = torch.clamp(supervision_segments, min=0)
-        indices = torch.argsort(supervision_segments[:, 2], descending=True)
-        supervision_segments = supervision_segments[indices]
-        texts = supervisions['text']
-        assert feature.ndim == 3
+        texts = batch['supervisions']['text']
 
-        feature = feature.to(device)
-        # at entry, feature is [N, T, C]
-        feature = feature.permute(0, 2, 1)  # now feature is [N, C, T]
-        nnet_output, encoder_memory, memory_mask = model(feature, supervisions)
-        nnet_output = nnet_output.permute(0, 2, 1)
+        hyps_dict = decode_one_batch(batch=batch,
+                                     model=model,
+                                     HLG=HLG,
+                                     output_beam_size=output_beam_size,
+                                     num_paths=num_paths,
+                                     use_whole_lattice=use_whole_lattice,
+                                     G=G)
 
-        # TODO(Liyong Guo): Tune this bias
-        # blank_bias = 0.0
-        # nnet_output[:, :, 0] += blank_bias
+        for lm_scale, hyps in hyps_dict.items():
+            this_batch = []
+            assert len(hyps) == len(texts)
 
-        with torch.no_grad():
-            dense_fsa_vec = k2.DenseFsaVec(nnet_output, supervision_segments)
+            for i in range(len(texts)):
+                hyp_words = [symbols.get(x) for x in hyps[i]]
+                ref_words = texts[i].split(' ')
+                this_batch.append((ref_words, hyp_words))
 
-            lattices = k2.intersect_dense_pruned(ctc_topo, dense_fsa_vec, 20.0,
-                                                 output_beam_size, 30, 10000)
-
-        best_paths = k2.shortest_path(lattices, use_double_scores=True)
-        hyps = get_texts(best_paths, indices)
-        assert len(hyps) == len(texts)
-
-        for i in range(len(texts)):
-            pieces = [numericalizer.tokens_list[token_id] for token_id in hyps[i]]
-            hyp_words = numericalizer.tokenizer.DecodePieces(pieces).split(' ')
-            ref_words = texts[i].split(' ')
-            results.append((ref_words, hyp_words))
+            results[lm_scale].extend(this_batch)
 
         if batch_idx % 10 == 0:
             logging.info(
                 'batch {}, cuts processed until now is {}/{} ({:.6f}%)'.format(
                     batch_idx, num_cuts, tot_num_cuts,
                     float(num_cuts) / tot_num_cuts * 100))
+
         num_cuts += len(texts)
+
     return results
 
 
@@ -97,19 +315,45 @@ def get_parser():
         default="conformer",
         choices=["conformer"],
         help="Model type.")
-
+    parser.add_argument(
+        '--epoch',
+        type=int,
+        default=35,
+        help="Decoding epoch.")
+    parser.add_argument(
+        '--avg',
+        type=int,
+        default=10,
+        help="Number of checkpionts to average. Automaticly select "
+             "consecutive checkpoints before checkpoint specified by'--epoch'. ")
+    parser.add_argument(
+        '--att-rate',
+        type=float,
+        default=0.7,
+        help="Attention loss rate.")
     parser.add_argument(
         '--nhead',
         type=int,
         default=8,
         help="Number of attention heads in transformer.")
-
     parser.add_argument(
         '--attention-dim',
         type=int,
         default=512,
         help="Number of units in transformer attention layers.")
-
+    parser.add_argument(
+        '--output-beam-size',
+        type=float,
+        default=8,
+        help='Output beam size. Used in k2.intersect_dense_pruned.'\
+             'Choose a large value (e.g., 20), for 1-best decoding '\
+             'and n-best rescoring. Choose a small value (e.g., 8) for ' \
+             'rescoring with the whole lattice')
+    parser.add_argument(
+        '--use-lm-rescoring',
+        type=str2bool,
+        default=True,
+        help='When enabled, it uses LM for rescoring')
     parser.add_argument(
         '--num-paths',
         type=int,
@@ -138,17 +382,6 @@ def get_parser():
         default=False,
         help='When enabled, train an identical model to the espnet SOTA released model'
         "url: https://zenodo.org/record/4604066#.YNAAHmgzZPY")
-    parser.add_argument(
-        '--epoch',
-        type=int,
-        default=29,
-        help="Decoding epoch.")
-    parser.add_argument(
-        '--avg',
-        type=int,
-        default=5,
-        help="Number of checkpionts to average. Automaticly select "
-             "consecutive checkpoints before checkpoint specified by'--epoch'. ")
 
     parser.add_argument(
         '--generate-release-model',
@@ -161,17 +394,14 @@ def get_parser():
         type=str2bool,
         default=False,
         help='When enabled, decode and evaluate with the released model')
-    parser.add_argument(
-        '--att-rate',
-        type=float,
-        default=0.7,
-        help="Attention loss rate.")
 
     parser.add_argument(
-        '--output-beam-size',
+        '--lr-factor',
         type=float,
-        default=8,
-        help='Output beam size. Used in k2.intersect_dense_pruned.')
+        default=10.0,
+        help='Learning rate factor for Noam optimizer.'
+    )
+
 
     return parser
 
@@ -187,22 +417,36 @@ def main():
     att_rate = args.att_rate
     model_type = args.model_type
     epoch = args.epoch
+    num_paths = args.num_paths
+    use_lm_rescoring = args.use_lm_rescoring
+    use_whole_lattice = False
+    if use_lm_rescoring and num_paths < 1:
+        # It doesn't make sense to use n-best list for rescoring
+        # when n is less than 1
+        use_whole_lattice = True
 
+    output_beam_size = args.output_beam_size
+
+    # load L, G, symbol_table
+    logging.debug("About to load phone and word symbols")
+    lang_dir = Path('./data/lang_bpe2/')
+    symbol_table = k2.SymbolTable.from_file(lang_dir / 'words.txt')
+    phone_symbol_table = k2.SymbolTable.from_file(lang_dir / 'phones.txt')
+    phone_ids = get_phone_symbols(phone_symbol_table)
+
+    logging.debug("About to load model")
     # Note: Use "export CUDA_VISIBLE_DEVICES=N" to setup device id to N
     # device = torch.device('cuda', 1)
     device = torch.device('cuda')
 
-    lang_dir = Path('data/en_token_list/bpe_unigram5000/')
-    bpe_model_path = lang_dir / 'bpe.model'
-    tokens_file = lang_dir / 'tokens.txt'
-    numericalizer = Numericalizer.build_numericalizer(bpe_model_path, tokens_file)
 
     if att_rate != 0.0:
         num_decoder_layers = 6
     else:
         num_decoder_layers = 0
 
-    num_classes = len(numericalizer.tokens_list)
+    num_classes = len(phone_ids) + 1
+    assert num_classes == 5000, print(num_classes)
     if model_type == "conformer":
         model = Conformer(
             num_features=80,
@@ -220,7 +464,7 @@ def main():
     else:
         raise NotImplementedError("Model of type " + str(model_type) + " is not verified")
 
-    exp_dir = Path(f'exp-bpe-{model_type}-{attention_dim}-{nhead}-noam/')
+    exp_dir = Path(f'exp-bpe-lrfactor{args.lr_factor}-{model_type}-{attention_dim}-{nhead}-noam/')
     if args.decode_with_released_model is True:
         released_model_path = exp_dir / f'model-epoch-{epoch}-avg-{avg}.pt'
         model.load_state_dict(torch.load(released_model_path))
@@ -251,31 +495,122 @@ def main():
         logging.info("Loading pre-compiled ctc topo fst")
         d_ctc_topo = torch.load(ctc_path)
         ctc_topo = k2.Fsa.from_dict(d_ctc_topo)
-    ctc_topo = ctc_topo.to(device)
 
-    feature_dir = Path('exp/data')
+    if not os.path.exists(lang_dir / 'HLG.pt'):
+        logging.debug("Loading L_disambig.fst.txt")
+        with open(lang_dir / 'L_disambig.fst.txt') as f:
+            L = k2.Fsa.from_openfst(f.read(), acceptor=False)
+        logging.debug("Loading G.fst.txt")
+        with open(lang_dir / 'G.fst.txt') as f:
+            G = k2.Fsa.from_openfst(f.read(), acceptor=False)
+        first_phone_disambig_id = find_first_disambig_symbol(phone_symbol_table)
+        first_word_disambig_id = find_first_disambig_symbol(symbol_table)
+        HLG = compile_HLG(L=L,
+                         G=G,
+                         H=ctc_topo,
+                         labels_disambig_id_start=first_phone_disambig_id,
+                         aux_labels_disambig_id_start=first_word_disambig_id)
+        torch.save(HLG.as_dict(), lang_dir / 'HLG.pt')
+    else:
+        logging.debug("Loading pre-compiled HLG")
+        d = torch.load(lang_dir / 'HLG.pt')
+        HLG = k2.Fsa.from_dict(d)
+
+    if use_lm_rescoring:
+        if use_whole_lattice:
+            logging.info('Rescoring with the whole lattice')
+        else:
+            logging.info(f'Rescoring with n-best list, n is {num_paths}')
+        first_word_disambig_id = find_first_disambig_symbol(symbol_table)
+        if not os.path.exists(lang_dir / 'G_4_gram.pt'):
+            logging.debug('Loading G_4_gram.fst.txt')
+            with open(lang_dir / 'G_4_gram.fst.txt') as f:
+                G = k2.Fsa.from_openfst(f.read(), acceptor=False)
+                # G.aux_labels is not needed in later computations, so
+                # remove it here.
+                del G.aux_labels
+                # CAUTION(fangjun): The following line is crucial.
+                # Arcs entering the back-off state have label equal to #0.
+                # We have to change it to 0 here.
+                G.labels[G.labels >= first_word_disambig_id] = 0
+                G = k2.create_fsa_vec([G]).to(device)
+                G = k2.arc_sort(G)
+                torch.save(G.as_dict(), lang_dir / 'G_4_gram.pt')
+        else:
+            logging.debug('Loading pre-compiled G_4_gram.pt')
+            d = torch.load(lang_dir / 'G_4_gram.pt')
+            G = k2.Fsa.from_dict(d).to(device)
+
+        if use_whole_lattice:
+            # Add epsilon self-loops to G as we will compose
+            # it with the whole lattice later
+            G = k2.add_epsilon_self_loops(G)
+            G = k2.arc_sort(G)
+            G = G.to(device)
+        # G.lm_scores is used to replace HLG.lm_scores during
+        # LM rescoring.
+        G.lm_scores = G.scores.clone()
+    else:
+        logging.debug('Decoding without LM rescoring')
+        G = None
+        if num_paths > 1:
+            logging.debug(f'Use n-best list decoding, n is {num_paths}')
+        else:
+            logging.debug('Use 1-best decoding')
+
+    logging.debug("convert HLG to device")
+    HLG = HLG.to(device)
+    HLG.aux_labels = k2.ragged.remove_values_eq(HLG.aux_labels, 0)
+    HLG.requires_grad_(False)
+
+    if not hasattr(HLG, 'lm_scores'):
+        HLG.lm_scores = HLG.scores.clone()
 
     librispeech = LibriSpeechAsrDataModule(args)
     test_sets = ['test-clean', 'test-other']
     for test_set, test_dl in zip(test_sets, librispeech.test_dataloaders()):
-        results = decode(dataloader=test_dl,
-                         model=model,
-                         device=device,
-                         ctc_topo=ctc_topo,
-                         numericalizer=numericalizer,
-                         num_paths=args.num_paths,
-                         output_beam_size=args.output_beam_size)
+        logging.info(f'* DECODING: {test_set}')
 
-        recog_path = exp_dir / f'recogs-{test_set}.txt'
-        store_transcripts(path=recog_path, texts=results)
-        logging.info(f'The transcripts are stored in {recog_path}')
+        test_set_wers = dict()
+        results_dict = decode(dataloader=test_dl,
+                              model=model,
+                              HLG=HLG,
+                              symbols=symbol_table,
+                              num_paths=num_paths,
+                              G=G,
+                              use_whole_lattice=use_whole_lattice,
+                              output_beam_size=output_beam_size)
 
-        # The following prints out WERs, per-word error statistics and aligned
-        # ref/hyp pairs.
-        errs_filename = exp_dir / f'errs-{test_set}.txt'
-        with open(errs_filename, 'w') as f:
-            write_error_stats(f, test_set, results)
-        logging.info('Wrote detailed error stats to {}'.format(errs_filename))
+        for key, results in results_dict.items():
+            recog_path = exp_dir / f'recogs-{test_set}-{key}.txt'
+            store_transcripts(path=recog_path, texts=results)
+            logging.info(f'The transcripts are stored in {recog_path}')
 
-if __name__ == "__main__":
+            # The following prints out WERs, per-word error statistics and aligned
+            # ref/hyp pairs.
+            errs_filename = exp_dir / f'errs-{test_set}-{key}.txt'
+            with open(errs_filename, 'w') as f:
+                wer = write_error_stats(f, f'{test_set}-{key}', results)
+                test_set_wers[key] = wer
+
+            logging.info('Wrote detailed error stats to {}'.format(errs_filename))
+        test_set_wers = sorted(test_set_wers.items(), key=lambda x: x[1])
+        errs_info = exp_dir / f'wer-summary-{test_set}.txt'
+        with open(errs_info, 'w') as f:
+            print('settings\tWER', file=f)
+            for key, val in test_set_wers:
+                print('{}\t{}'.format(key, val), file=f)
+
+        s = '\nFor {}, WER of different settings are:\n'.format(test_set)
+        note = '\tbest for {}'.format(test_set)
+        for key, val in test_set_wers:
+            s += '{}\t{}{}\n'.format(key, val, note)
+            note=''
+        logging.info(s)
+
+
+torch.set_num_threads(1)
+torch.set_num_interop_threads(1)
+
+if __name__ == '__main__':
     main()

--- a/egs/librispeech/asr/simple_v1/bpe_run.sh
+++ b/egs/librispeech/asr/simple_v1/bpe_run.sh
@@ -12,8 +12,12 @@ if [ $download_model -eq 1 ]; then
   if [ -d snowfall_bpe_model ]; then
     echo "Model seems already been dowloaded"
   else
+    if ! type git-lfs >/dev/null 2>&1; then
+          echo 'Please Install git-lfs to download trained models';
+          exit 0
+    fi
     git clone https://huggingface.co/GuoLiyong/snowfall_bpe_model
-    for sub_dir in data exp-bpe-conformer-512-8-noam; do
+    for sub_dir in data exp-bpe-lrfactor10.0-conformer-512-8-noam; do
       ln -sf snowfall_bpe_model/$sub_dir ./
     done
   fi
@@ -25,9 +29,80 @@ if [ ! -f exp/data/cuts_test-clean.json.gz ]; then
 fi
 
 if [ $stage -le 1 ]; then
-  export CUDA_VISIBLE_DEVICES=3
+  local/download_lm.sh "openslr.org/resources/11" data/local/lm
+fi
+
+if [ $stage -le 2 ]; then
+  dir=data/lang_bpe2
+  mkdir -p $dir
+  token_file=./data/en_token_list/bpe_unigram5000/tokens.txt
+  model_file=./data/en_token_list/bpe_unigram5000/bpe.model
+  cp $token_file $dir/tokens.txt
+  ln -fv $dir/tokens.txt $dir/phones.txt
+  echo "<eps> 0" > $dir/words.txt
+  echo "<UNK> 1" >> $dir/words.txt
+  cat data/local/lm/librispeech-vocab.txt | sort | uniq |
+    awk '{print $1 " " NR+1}' >> $dir/words.txt
+
+  if [ ! -f $dir/lexicon.txt ]; then
+    python3 ./generate_bpe_lexicon.py \
+      --model-file $model_file \
+      --words-file $dir/words.txt > $dir/lexicon.txt
+  fi
+
+  if [ ! -f $dir/lexiconp.txt ]; then
+    echo "**Creating $dir/lexiconp.txt from $dir/lexicon.txt"
+    perl -ape 's/(\S+\s+)(.+)/${1}1.0\t$2/;' < $dir/lexicon.txt > $dir/lexiconp.txt || exit 1
+  fi
+
+  if ! grep "#0" $dir/words.txt > /dev/null 2>&1; then
+    max_word_id=$(tail -1 $dir/words.txt | awk '{print $2}')
+    echo "#0 $((max_word_id+1))" >> $dir/words.txt
+  fi
+
+  ndisambig=$(local/add_lex_disambig.pl --pron-probs $dir/lexiconp.txt $dir/lexiconp_disambig.txt)
+  if ! grep "#0" $dir/phones.txt > /dev/null 2>&1 ; then
+    max_phone_id=$(tail -1 $dir/phones.txt | awk '{print $2}')
+    for i in $(seq 0 $ndisambig); do
+      echo "#$i $((i+max_phone_id+1))"
+    done >> $dir/phones.txt
+  fi
+
+  if [ ! -f $dir/L_disambig.fst.txt ]; then
+    wdisambig_phone=$(echo "#0" | local/sym2int.pl $dir/phones.txt)
+    wdisambig_word=$(echo "#0" | local/sym2int.pl $dir/words.txt)
+
+    local/make_lexicon_fst.py \
+      $dir/lexiconp_disambig.txt | \
+      local/sym2int.pl --map-oov 1 -f 3 $dir/phones.txt | \
+      local/sym2int.pl -f 4 $dir/words.txt | \
+      local/fstaddselfloops.pl $wdisambig_phone $wdisambig_word > $dir/L_disambig.fst.txt || exit 1
+  fi
+
+  if [ ! -f $dir/G.fst.txt ]; then
+    python3 -m kaldilm \
+      --read-symbol-table="$dir/words.txt" \
+      --disambig-symbol='#0' \
+      --max-order=3 \
+      data/local/lm/lm_tgmed.arpa > $dir/G.fst.txt
+  else
+    echo "Skip generating $dir/G.fst.txt"
+  fi
+  if [ ! -f $dir/G_4_gram.fst.txt ]; then
+    python3 -m kaldilm \
+      --read-symbol-table="$dir/words.txt" \
+      --disambig-symbol='#0' \
+      --max-order=4 \
+      data/local/lm/lm_fglarge.arpa >$dir/G_4_gram.fst.txt
+  else
+    echo "Skip generating data/lang_nosp/G_4_gram.fst.txt"
+  fi
+fi
+
+if [ $stage -le 3 ]; then
+  export CUDA_VISIBLE_DEVICES=2
   python bpe_ctc_att_conformer_decode.py \
-    --max-duration=10 \
+    --max-duration=5 \
     --generate-release-model=False \
     --decode_with_released_model=True
 fi

--- a/egs/librispeech/asr/simple_v1/generate_bpe_lexicon.py
+++ b/egs/librispeech/asr/simple_v1/generate_bpe_lexicon.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+# Copyright (c)  2021  Xiaomi Corporation (authors: Fangjun Kuang)
+
+from pathlib import Path
+from typing import List
+
+import argparse
+import sentencepiece as spm
+
+
+def read_words(words_txt: str, excluded=['<eps>', '<UNK>']) -> List[str]:
+    '''Read words_txt and return a list of words.
+    The file words_txt has the following format:
+        <word> <id>
+    That is, every line has two fields. This function
+    extracts the first field.
+    Args:
+      words_txt:
+        Filename of words.txt.
+      excluded:
+        words in this list are not returned.
+    Returns:
+      Return a list of words.
+    '''
+    ans = []
+    with open(words_txt, 'r', encoding='latin-1') as f:
+        for line in f:
+            word, _ = line.strip().split()
+            if word not in excluded:
+                ans.append(word)
+    return ans
+
+
+def main():
+    parser = argparse.ArgumentParser()
+
+    parser.add_argument('--model-file',
+                        type=str,
+                        help='Pre-trained BPE model file')
+
+    parser.add_argument('--words-file', type=str, help='Path to words.txt')
+
+    args = parser.parse_args()
+    model_file = args.model_file
+    words_txt = args.words_file
+    assert Path(model_file).is_file(), f'{model_file} does not exist'
+    assert Path(words_txt).is_file(), f'{words_txt} does not exist'
+
+    words = read_words(words_txt)
+
+    sp = spm.SentencePieceProcessor()
+    sp.load(model_file)
+
+    for word in words:
+        pieces = sp.EncodeAsPieces(word.upper())
+        print(word, ' '.join(pieces))
+
+    print('<UNK>', '<UNK>')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
1. A better model trained by (ctc + label_smooth_loss #219)  is released
2. 4-gram rescore is integrated with refering to #215


  | Wer% on test_clean | wer% on test_other
-- | -- | --
Encoder + ctc | 3.32 | 7.96
Encoder + (ctc + 3-gram) + 4-gram lattice rescore | 2.92 | *（failed because of an OOM issue, working on this)


Wer result on test_clean:
![38af9a2a0505f616a1fb9eaa7817c1a](https://user-images.githubusercontent.com/14951566/124417143-148e6100-dd8b-11eb-8fbf-2a8d49eaca93.png)

