### PR TITLE
Complimentary sampler update following Lhotse's changes

### DIFF
--- a/egs/aishell/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/aishell/asr/simple_v1/mmi_att_transformer_decode.py
@@ -38,7 +38,7 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
     num_batches = None
     try:
         num_batches = len(dataloader)
-    except AttributeError:
+    except TypeError:
         pass
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)

--- a/egs/aishell/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/aishell/asr/simple_v1/mmi_att_transformer_decode.py
@@ -6,16 +6,17 @@
 # Apache 2.0
 
 import argparse
-import k2
 import logging
-import numpy as np
 import os
-import torch
-from k2 import Fsa, SymbolTable
-from kaldialign import edit_distance
 from pathlib import Path
 from typing import List
 from typing import Union
+
+import k2
+import numpy as np
+import torch
+from k2 import Fsa, SymbolTable
+from kaldialign import edit_distance
 
 from snowfall.common import average_checkpoint
 from snowfall.common import find_first_disambig_symbol
@@ -25,8 +26,8 @@ from snowfall.common import setup_logger
 from snowfall.data import AishellAsrDataModule
 from snowfall.decoding.graph import compile_LG
 from snowfall.models import AcousticModel
-from snowfall.models.transformer import Transformer
 from snowfall.models.conformer import Conformer
+from snowfall.models.transformer import Transformer
 from snowfall.training.ctc_graph import build_ctc_topo
 from snowfall.training.mmi_graph import create_bigram_phone_lm
 from snowfall.training.mmi_graph import get_phone_symbols
@@ -34,7 +35,11 @@ from snowfall.training.mmi_graph import get_phone_symbols
 
 def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
            device: Union[str, torch.device], LG: Fsa, symbols: SymbolTable):
-    tot_num_cuts = len(dataloader.dataset.cuts)
+    num_batches = None
+    try:
+        num_batches = len(dataloader)
+    except AttributeError:
+        pass
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)
     for batch_idx, batch in enumerate(dataloader):
@@ -83,10 +88,8 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
             results.append((ref_words, hyp_words))
 
         if batch_idx % 10 == 0:
-            logging.info(
-                'batch {}, cuts processed until now is {}/{} ({:.6f}%)'.format(
-                    batch_idx, num_cuts, tot_num_cuts,
-                    float(num_cuts) / tot_num_cuts * 100))
+            batch_str = f"{batch_idx}" if num_batches is None else f"{batch_idx}/{num_batches}"
+            logging.info(f"batch {batch_str}, number of cuts processed until now is {num_cuts}")
 
         num_cuts += len(texts)
 

--- a/egs/gigaspeech/asr/simple_v1/asr_datamodule.py
+++ b/egs/gigaspeech/asr/simple_v1/asr_datamodule.py
@@ -2,6 +2,7 @@
 # Apache 2.0
 import argparse
 import logging
+import warnings
 from functools import lru_cache
 from pathlib import Path
 from typing import List, Union
@@ -52,73 +53,91 @@ class GigaSpeechAsrDataModule(DataModule):
     def add_arguments(cls, parser: argparse.ArgumentParser):
         super().add_arguments(parser)
         group = parser.add_argument_group(
-            title='ASR data related options',
-            description='These options are used for the preparation of PyTorch DataLoaders '
-                        'from Lhotse CutSet\'s -- they control the effective batch sizes, '
-                        'sampling strategies, applied data augmentations, etc.'
+            title="ASR data related options",
+            description="These options are used for the preparation of PyTorch DataLoaders "
+                        "from Lhotse CutSet's -- they control the effective batch sizes, "
+                        "sampling strategies, applied data augmentations, etc.",
         )
         group.add_argument(
-            '--feature-dir',
+            "--feature-dir",
             type=Path,
-            default=Path('exp/data'),
-            help='Path to directory with train/valid/test cuts.'
+            default=Path("exp/data"),
+            help="Path to directory with train/valid/test cuts.",
         )
         group.add_argument(
-            '--max-duration',
+            "--max-duration",
             type=int,
             default=500.0,
-            help="Maximum pooled recordings duration (seconds) in a single batch.")
-        group.add_argument(
-            '--bucketing-sampler',
-            type=str2bool,
-            default=False,
-            help='When enabled, the batches will come from buckets of '
-                 'similar duration (saves padding frames).')
-        group.add_argument(
-            '--num-buckets',
-            type=int,
-            default=30,
-            help='The number of buckets for the BucketingSampler'
-                 '(you might want to increase it for larger datasets).')
-        group.add_argument(
-            '--concatenate-cuts',
-            type=str2bool,
-            default=True,
-            help='When enabled, utterances (cuts) will be concatenated '
-                 'to minimize the amount of padding.')
-        group.add_argument(
-            '--duration-factor',
-            type=float,
-            default=1.0,
-            help='Determines the maximum duration of a concatenated cut '
-                 'relative to the duration of the longest cut in a batch.')
-        group.add_argument(
-            '--gap',
-            type=float,
-            default=1.0,
-            help='The amount of padding (in seconds) inserted between concatenated cuts. '
-                 'This padding is filled with noise when noise augmentation is used.')
-        group.add_argument(
-            '--on-the-fly-feats',
-            type=str2bool,
-            default=False,
-            help='When enabled, use on-the-fly cut mixing and feature extraction. '
-                 'Will drop existing precomputed feature manifests if available.'
+            help="Maximum pooled recordings duration (seconds) in a single batch.",
         )
         group.add_argument(
-            '--shuffle',
+            "--bucketing-sampler",
             type=str2bool,
-            default=True,
-            help='When enabled (=default), the examples will be shuffled for each epoch.'
-            )
+            default=False,
+            help="When enabled, the batches will come from buckets of "
+                 "similar duration (saves padding frames).",
+        )
         group.add_argument(
-            '--check-cuts',
+            "--num-buckets",
+            type=int,
+            default=30,
+            help="The number of buckets for the BucketingSampler"
+                 "(you might want to increase it for larger datasets).",
+        )
+        group.add_argument(
+            "--concatenate-cuts",
             type=str2bool,
             default=True,
-            help='When enabled (=default), we will iterate over the whole training cut set '
-                 'to validate it. It should be disabled when using Apache Arrow manifests '
-                 'to avoid an excessive starting time of the script with datasets>1000h.'
-            )
+            help="When enabled, utterances (cuts) will be concatenated "
+                 "to minimize the amount of padding.",
+        )
+        group.add_argument(
+            "--duration-factor",
+            type=float,
+            default=1.0,
+            help="Determines the maximum duration of a concatenated cut "
+                 "relative to the duration of the longest cut in a batch.",
+        )
+        group.add_argument(
+            "--gap",
+            type=float,
+            default=1.0,
+            help="The amount of padding (in seconds) inserted between concatenated cuts. "
+                 "This padding is filled with noise when noise augmentation is used.",
+        )
+        group.add_argument(
+            "--on-the-fly-feats",
+            type=str2bool,
+            default=False,
+            help="When enabled, use on-the-fly cut mixing and feature extraction. "
+                 "Will drop existing precomputed feature manifests if available.",
+        )
+        group.add_argument(
+            "--shuffle",
+            type=str2bool,
+            default=True,
+            help="When enabled (=default), the examples will be shuffled for each epoch.",
+        )
+        group.add_argument(
+            "--return-cuts",
+            type=str2bool,
+            default=True,
+            help="When enabled, each batch will have the field: batch['supervisions']['cut']"
+                 " with the cuts that were used to construct it.",
+        )
+        group.add_argument(
+            "--num-workers",
+            type=int,
+            default=4,
+            help="The number of training dataloader workers that collect the batches.",
+        )
+        group.add_argument(
+            "--num-workers-inner",
+            type=int,
+            default=16,
+            help="The number of sub-workers (replicated for each of training dataloader"
+                 " workers) that parallelize the I/O to collect each batch.",
+        )
 
         # GigaSpeech specific arguments
         group.add_argument(
@@ -144,33 +163,33 @@ class GigaSpeechAsrDataModule(DataModule):
                  "to seek for extra acoustic context. Available values: (left|right|center|random).",
         )
         group.add_argument(
-            '--use-context-for-test',
+            "--use-context-for-test",
             type=str2bool,
             default=False,
-            help='Should we read cuts with acoustic context or without it. '
-                 '(note: for now, they may contain duplicated segments)'
+            help="Should we read cuts with acoustic context or without it. "
+                 "(note: for now, they may contain duplicated segments)",
         )
         group.add_argument(
-            '--small-dev',
+            "--small-dev",
             type=str2bool,
             default=False,
-            help='Should we use only 1000 utterances for dev (speeds up training)'
+            help="Should we use only 1000 utterances for dev (speeds up training)",
         )
 
     def validate_args(self):
-        if self.args.subset in ['L', 'XL']:
+        if self.args.subset in ["L", "XL"]:
             assert (
-                self.args.shuffle == False
+                    self.args.shuffle == False
             ), "For GigaSpeech L/XL, you must use --shuffle 0 to avoid eagerly reading pyarrow manifests."
             assert (
-                self.args.check_cuts == False
-            ), "For GigaSpeech L/XL, you must use --check-cuts 0 to avoid eagerly reading pyarrow manifests."
-            assert (
-                self.args.bucketing_sampler == False
+                    self.args.bucketing_sampler == False
             ), "For GigaSpeech L/XL, you must use --bucketing-sampler 0 to avoid eagerly reading pyarrow manifests."
-            assert (
-                self.args.on_the_fly_feats == True
-            ), "For GigaSpeech L/XL, you must use --on-the-fly-feats 1 as we do not pre-compute them by default."
+            if not self.args.on_the_fly_feats:
+                warnings.warn(
+                    "For GigaSpeech L/XL, we advise to set --on-the-fly-feats 1,"
+                    " as we do not pre-compute them by default. If you pre-computed them,"
+                    " ignore this warning."
+                )
 
     def train_dataloaders(self) -> DataLoader:
         self.validate_args()
@@ -178,32 +197,36 @@ class GigaSpeechAsrDataModule(DataModule):
         cuts_train = self.train_cuts()
 
         logging.info("About to get Musan cuts")
-        cuts_musan = load_manifest(self.args.feature_dir / 'cuts_musan.json.gz')
+        cuts_musan = load_manifest(self.args.feature_dir / "cuts_musan.json.gz")
 
         logging.info("About to create train dataset")
         transforms = [CutMix(cuts=cuts_musan, prob=0.5, snr=(10, 20))]
         if self.args.concatenate_cuts:
-            logging.info(f'Using cut concatenation with duration factor '
-                         f'{self.args.duration_factor} and gap {self.args.gap}.')
+            logging.info(
+                f"Using cut concatenation with duration factor "
+                f"{self.args.duration_factor} and gap {self.args.gap}."
+            )
             # Cut concatenation should be the first transform in the list,
             # so that if we e.g. mix noise in, it will fill the gaps between different utterances.
             transforms = [
                              CutConcatenate(
-                                 duration_factor=self.args.duration_factor,
-                                 gap=self.args.gap
+                                 duration_factor=self.args.duration_factor, gap=self.args.gap
                              )
                          ] + transforms
 
         input_transforms = [
-            SpecAugment(num_frame_masks=2, features_mask_size=27, num_feature_masks=2, frames_mask_size=100)
+            SpecAugment(
+                num_frame_masks=2,
+                features_mask_size=27,
+                num_feature_masks=2,
+                frames_mask_size=100,
+            )
         ]
 
         train = K2SpeechRecognitionDataset(
-            cuts_train,
             cut_transforms=transforms,
             input_transforms=input_transforms,
-            return_cuts=True,
-            check_inputs=self.args.check_cuts,
+            return_cuts=self.args.return_cuts,
         )
 
         if self.args.on_the_fly_feats:
@@ -214,41 +237,42 @@ class GigaSpeechAsrDataModule(DataModule):
             # # but in principle the transforms order doesn't have to be strict (e.g. could be randomized)
             # transforms = [PerturbSpeed(factors=[0.9, 1.1], p=2 / 3)] + transforms
             train = K2SpeechRecognitionDataset(
-                cuts=cuts_train,
                 cut_transforms=transforms,
-                input_strategy=OnTheFlyFeatures(Fbank(FbankConfig(num_mel_bins=80)), num_workers=20),
+                input_strategy=OnTheFlyFeatures(
+                    Fbank(FbankConfig(num_mel_bins=80)),
+                    num_workers=self.args.num_workers_inner,
+                ),
                 input_transforms=input_transforms,
-                return_cuts=True,
-                check_inputs=self.args.check_cuts,
+                return_cuts=self.args.return_cuts,
             )
 
         if self.args.bucketing_sampler:
-            logging.info('Using BucketingSampler.')
+            logging.info("Using BucketingSampler.")
             train_sampler = BucketingSampler(
                 cuts_train,
                 max_duration=self.args.max_duration,
                 shuffle=self.args.shuffle,
-                num_buckets=self.args.num_buckets
+                num_buckets=self.args.num_buckets,
             )
         else:
-            logging.info('Using SingleCutSampler.')
+            logging.info("Using SingleCutSampler.")
             train_sampler = SingleCutSampler(
                 cuts_train,
                 max_duration=self.args.max_duration,
                 shuffle=self.args.shuffle,
             )
         logging.info("About to create train dataloader")
-        #train_dl = DataLoader(
+        # train_dl = DataLoader(
         #    train,
         #    sampler=train_sampler,
         #    batch_size=None,
         #    num_workers=16,
         #    persistent_workers=True,
-        #)
+        # )
         train_dl = LhotseDataLoader(
             train,
             sampler=train_sampler,
-            num_workers=3,
+            num_workers=self.args.num_workers,
             prefetch_factor=5,
         )
         return train_dl
@@ -258,29 +282,27 @@ class GigaSpeechAsrDataModule(DataModule):
         logging.info("About to get dev cuts")
         cuts_valid = self.valid_cuts()
 
-        transforms = [ ]
+        transforms = []
         if self.args.concatenate_cuts:
-            transforms = [ CutConcatenate(
-                                 duration_factor=self.args.duration_factor,
-                                 gap=self.args.gap)
-                          ] + transforms
-
+            transforms = [
+                             CutConcatenate(
+                                 duration_factor=self.args.duration_factor, gap=self.args.gap
+                             )
+                         ] + transforms
 
         logging.info("About to create dev dataset")
         if self.args.on_the_fly_feats:
             validate = K2SpeechRecognitionDataset(
-                cuts_valid,
                 cut_transforms=transforms,
-                input_strategy=OnTheFlyFeatures(Fbank(FbankConfig(num_mel_bins=80)), num_workers=8),
-                return_cuts=True,
-                check_inputs=self.args.check_cuts,
+                input_strategy=OnTheFlyFeatures(
+                    Fbank(FbankConfig(num_mel_bins=80)), num_workers=8
+                ),
+                return_cuts=self.args.return_cuts,
             )
         else:
             validate = K2SpeechRecognitionDataset(
-                cuts_valid,
                 cut_transforms=transforms,
-                return_cuts=True,
-                check_inputs=self.args.check_cuts,
+                return_cuts=self.args.return_cuts,
             )
         valid_sampler = SingleCutSampler(
             cuts_valid,
@@ -288,13 +310,13 @@ class GigaSpeechAsrDataModule(DataModule):
             shuffle=False,
         )
         logging.info("About to create dev dataloader")
-        #valid_dl = DataLoader(
+        # valid_dl = DataLoader(
         #    validate,
         #    sampler=valid_sampler,
         #    batch_size=None,
         #    num_workers=8,
         #    persistent_workers=True,
-        #)
+        # )
         valid_dl = LhotseDataLoader(
             validate,
             sampler=valid_sampler,
@@ -313,18 +335,16 @@ class GigaSpeechAsrDataModule(DataModule):
         for cuts_test in cuts:
             logging.debug("About to create test dataset")
             test = K2SpeechRecognitionDataset(
-                cuts_test,
                 input_strategy=(
                     OnTheFlyFeatures(Fbank(FbankConfig(num_mel_bins=80)), num_workers=8)
                     if self.args.on_the_fly_feats
                     else PrecomputedFeatures()
                 ),
-                return_cuts=True,
-                check_inputs=self.args.check_cuts,
+                return_cuts=self.args.return_cuts,
             )
             sampler = SingleCutSampler(cuts_test, max_duration=self.args.max_duration)
             logging.debug("About to create test dataloader")
-            #test_dl = DataLoader(test, batch_size=None, sampler=sampler, num_workers=1)
+            # test_dl = DataLoader(test, batch_size=None, sampler=sampler, num_workers=1)
             test_dl = LhotseDataLoader(test, sampler=sampler, num_workers=2)
             test_loaders.append(test_dl)
 
@@ -336,18 +356,30 @@ class GigaSpeechAsrDataModule(DataModule):
     @lru_cache()
     def train_cuts(self) -> CutSet:
         logging.info("About to get train cuts")
-        # Note: for L and XL subsets, we are expecting that the training manifest is stored using pyarrow and pre-shuffled.
-        cuts_path_ext = 'jsonl.gz' if self.args.subset not in ['L', 'XL'] else 'arrow'
-        cuts_train = CutSet.from_file(
-            self.args.feature_dir
-            / f"gigaspeech_cuts_{self.args.subset}{get_context_suffix(self.args)}.{cuts_path_ext}"
+        path = (
+                self.args.feature_dir
+                / f"gigaspeech_cuts_{self.args.subset}{get_context_suffix(self.args)}.jsonl.gz"
         )
+        if self.args.subset in ["L", "XL"]:
+            # "L" and "XL" partitions are large enough that we have to read their manifests lazily;
+            # The "CutSet" holds a file handle and reads the items sequentially on-the-fly to avoid
+            # wasting memory and time pre-reading everything. Some operations on "CutSet" won't work,
+            # e.g. shuffling (or they would have read everything into memory in the process).
+            # We expect that the manifests read lazily are pre-shuffled, otherwise you might experience
+            # issues with convergence.
+            cuts_train = CutSet.from_jsonl_lazy(path)
+        else:
+            # For other subsets, just read everything into memory.
+            cuts_train = CutSet.from_file(path)
         return cuts_train
 
     @lru_cache()
     def valid_cuts(self) -> CutSet:
         if self.args.use_context_for_test:
-            path = self.args.feature_dir / f"gigaspeech_cuts_DEV{get_context_suffix(self.args)}.jsonl.gz"
+            path = (
+                    self.args.feature_dir
+                    / f"gigaspeech_cuts_DEV{get_context_suffix(self.args)}.jsonl.gz"
+            )
         else:
             path = self.args.feature_dir / f"gigaspeech_cuts_DEV.jsonl.gz"
         logging.info(f"About to get valid cuts from {path}")
@@ -360,7 +392,10 @@ class GigaSpeechAsrDataModule(DataModule):
     @lru_cache()
     def test_cuts(self) -> CutSet:
         if self.args.use_context_for_test:
-            path = self.args.feature_dir / f"gigaspeech_cuts_TEST{get_context_suffix(self.args)}.jsonl.gz"
+            path = (
+                    self.args.feature_dir
+                    / f"gigaspeech_cuts_TEST{get_context_suffix(self.args)}.jsonl.gz"
+            )
         else:
             path = self.args.feature_dir / f"gigaspeech_cuts_TEST.jsonl.gz"
         logging.info(f"About to get test cuts from {path}")

--- a/egs/gigaspeech/asr/simple_v1/ctc_decode.py
+++ b/egs/gigaspeech/asr/simple_v1/ctc_decode.py
@@ -38,7 +38,7 @@ def decode(
     num_batches = None
     try:
         num_batches = len(dataloader)
-    except AttributeError:
+    except TypeError:
         pass
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)

--- a/egs/gigaspeech/asr/simple_v1/ctc_decode.py
+++ b/egs/gigaspeech/asr/simple_v1/ctc_decode.py
@@ -29,13 +29,17 @@ from snowfall.training.ctc_graph import build_ctc_topo
 
 
 def decode(
-    dataloader: torch.utils.data.DataLoader,
-    model: AcousticModel,
-    device: Union[str, torch.device],
-    HLG: Fsa,
-    symbols: SymbolTable,
+        dataloader: torch.utils.data.DataLoader,
+        model: AcousticModel,
+        device: Union[str, torch.device],
+        HLG: Fsa,
+        symbols: SymbolTable,
 ):
-    tot_num_cuts = len(dataloader.dataset.cuts)
+    num_batches = None
+    try:
+        num_batches = len(dataloader)
+    except AttributeError:
+        pass
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)
     for batch_idx, batch in enumerate(dataloader):
@@ -90,14 +94,8 @@ def decode(
             results.append((ref_words, hyp_words))
 
         if batch_idx % 10 == 0:
-            logging.info(
-                "batch {}, cuts processed until now is {}/{} ({:.6f}%)".format(
-                    batch_idx,
-                    num_cuts,
-                    tot_num_cuts,
-                    float(num_cuts) / tot_num_cuts * 100,
-                )
-            )
+            batch_str = f"{batch_idx}" if num_batches is None else f"{batch_idx}/{num_batches}"
+            logging.info(f"batch {batch_str}, number of cuts processed until now is {num_cuts}")
 
         num_cuts += len(texts)
 

--- a/egs/gigaspeech/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/gigaspeech/asr/simple_v1/mmi_att_transformer_decode.py
@@ -304,7 +304,7 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
     num_batches = None
     try:
         num_batches = len(dataloader)
-    except AttributeError:
+    except TypeError:
         pass
 
     for batch_idx, batch in enumerate(dataloader):

--- a/egs/gigaspeech/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/gigaspeech/asr/simple_v1/mmi_att_transformer_decode.py
@@ -293,7 +293,6 @@ def decode_one_batch(batch: Dict[str, Any],
 def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
            HLG: Fsa, symbols: SymbolTable,
            num_paths: int, G: k2.Fsa, use_whole_lattice: bool, output_beam_size: float):
-    tot_num_cuts = len(dataloader.dataset.cuts)
     num_cuts = 0
     results = defaultdict(list)
     # results is a dict whose keys and values are:
@@ -302,8 +301,16 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
     #
     #  - value: It is a list of tuples (ref_words, hyp_words)
 
+    num_batches = None
+    try:
+        num_batches = len(dataloader)
+    except AttributeError:
+        pass
+
     for batch_idx, batch in enumerate(dataloader):
-        texts = batch['supervisions']['text']
+        # We remove the non-tensor valeus under key 'text' which enables this
+        # to run with TorchScript models.
+        texts = batch['supervisions'].pop('text')
 
         hyps_dict = decode_one_batch(batch=batch,
                                      model=model,
@@ -327,10 +334,8 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
         num_cuts += len(texts)
 
         if batch_idx % 10 == 0:
-            logging.info(
-                'batch {}, cuts processed until now is {}/{} ({:.6f}%)'.format(
-                    batch_idx, num_cuts, tot_num_cuts,
-                    float(num_cuts) / tot_num_cuts * 100))
+            batch_str = f"{batch_idx}" if num_batches is None else f"{batch_idx}/{num_batches}"
+            logging.info(f"batch {batch_str}, number of cuts processed until now is {num_cuts}")
 
     return results
 

--- a/egs/gigaspeech/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/gigaspeech/asr/simple_v1/mmi_att_transformer_decode.py
@@ -401,6 +401,12 @@ def get_parser():
         type=str2bool,
         default=True,
         help='When enabled, it uses vgg style network for subsampling')
+    parser.add_argument(
+        '--torchscript',
+        type=str2bool,
+        default=False,
+        help='When enabled, save a TorchScripted variant of the model in '
+             'exp_dir.')
     return parser
 
 
@@ -486,6 +492,13 @@ def main():
         checkpoints = [os.path.join(exp_dir, 'epoch-' + str(avg_epoch) + '.pt') for avg_epoch in
                        range(epoch - avg, epoch)]
         average_checkpoint(checkpoints, model)
+
+    if args.torchscript:
+        logging.info('Applying TorchScript to model...')
+        model = torch.jit.script(model)
+        ts_path = exp_dir / f'model_ts_epoch{epoch}_avg{avg}.pt'
+        logging.info(f'Storing the TorchScripted model in {ts_path}')
+        model.save(ts_path)
 
     model.to(device)
     model.eval()

--- a/egs/librispeech/asr/simple_v1/bpe_ctc_att_conformer_decode.py
+++ b/egs/librispeech/asr/simple_v1/bpe_ctc_att_conformer_decode.py
@@ -33,7 +33,7 @@ def decode(dataloader: torch.utils.data.DataLoader,
     num_batches = None
     try:
         num_batches = len(dataloader)
-    except AttributeError:
+    except TypeError:
         pass
     num_cuts = 0
     results = []

--- a/egs/librispeech/asr/simple_v1/ctc_att_transformer_decode.py
+++ b/egs/librispeech/asr/simple_v1/ctc_att_transformer_decode.py
@@ -35,7 +35,7 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
     num_batches = None
     try:
         num_batches = len(dataloader)
-    except AttributeError:
+    except TypeError:
         pass
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)

--- a/egs/librispeech/asr/simple_v1/ctc_att_transformer_decode.py
+++ b/egs/librispeech/asr/simple_v1/ctc_att_transformer_decode.py
@@ -5,18 +5,17 @@
 # Apache 2.0
 
 import argparse
-import k2
 import logging
-import numpy as np
 import os
+from pathlib import Path
+from typing import Union
+
+import k2
 import torch
 from k2 import Fsa, SymbolTable
 from kaldialign import edit_distance
-from pathlib import Path
-from typing import List
-from typing import Union
 
-from lhotse import CutSet, load_manifest
+from lhotse import load_manifest
 from lhotse.dataset import K2SpeechRecognitionDataset, SingleCutSampler
 from snowfall.common import average_checkpoint, store_transcripts
 from snowfall.common import find_first_disambig_symbol
@@ -25,15 +24,19 @@ from snowfall.common import load_checkpoint
 from snowfall.common import setup_logger
 from snowfall.decoding.graph import compile_HLG
 from snowfall.models import AcousticModel
-from snowfall.models.transformer import Transformer
 from snowfall.models.conformer import Conformer
+from snowfall.models.transformer import Transformer
 from snowfall.training.ctc_graph import build_ctc_topo
 from snowfall.training.mmi_graph import get_phone_symbols
 
 
 def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
            device: Union[str, torch.device], HLG: Fsa, symbols: SymbolTable):
-    tot_num_cuts = len(dataloader.dataset.cuts)
+    num_batches = None
+    try:
+        num_batches = len(dataloader)
+    except AttributeError:
+        pass
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)
     for batch_idx, batch in enumerate(dataloader):
@@ -82,10 +85,8 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
             results.append((ref_words, hyp_words))
 
         if batch_idx % 10 == 0:
-            logging.info(
-                'batch {}, cuts processed until now is {}/{} ({:.6f}%)'.format(
-                    batch_idx, num_cuts, tot_num_cuts,
-                    float(num_cuts) / tot_num_cuts * 100))
+            batch_str = f"{batch_idx}" if num_batches is None else f"{batch_idx}/{num_batches}"
+            logging.info(f"batch {batch_str}, number of cuts processed until now is {num_cuts}")
 
         num_cuts += len(texts)
 

--- a/egs/librispeech/asr/simple_v1/ctc_decode.py
+++ b/egs/librispeech/asr/simple_v1/ctc_decode.py
@@ -32,7 +32,7 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
     num_batches = None
     try:
         num_batches = len(dataloader)
-    except AttributeError:
+    except TypeError:
         pass
     num_cuts = 0
     results = []  # a list of pair (ref_words, hyp_words)

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
@@ -302,7 +302,7 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
     num_batches = None
     try:
         num_batches = len(dataloader)
-    except AttributeError:
+    except TypeError:
         pass
 
     for batch_idx, batch in enumerate(dataloader):

--- a/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
+++ b/egs/librispeech/asr/simple_v1/mmi_att_transformer_decode.py
@@ -39,38 +39,37 @@
 '''
 
 import argparse
-import k2
 import logging
-import numpy as np
 import os
-import torch
-from k2 import Fsa, SymbolTable
 from collections import defaultdict
 from pathlib import Path
 from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Union
 
+import k2
+import torch
+from k2 import Fsa, SymbolTable
 
 from snowfall.common import average_checkpoint, store_transcripts
 from snowfall.common import find_first_disambig_symbol
 from snowfall.common import get_texts
-from snowfall.common import write_error_stats
 from snowfall.common import load_checkpoint
 from snowfall.common import setup_logger
 from snowfall.common import str2bool
+from snowfall.common import write_error_stats
 from snowfall.data import LibriSpeechAsrDataModule
 from snowfall.decoding.graph import compile_HLG
 from snowfall.decoding.lm_rescore import rescore_with_n_best_list
 from snowfall.decoding.lm_rescore import rescore_with_whole_lattice
 from snowfall.models import AcousticModel
-from snowfall.models.transformer import Transformer
 from snowfall.models.conformer import Conformer
 from snowfall.models.contextnet import ContextNet
+from snowfall.models.transformer import Transformer
 from snowfall.training.ctc_graph import build_ctc_topo
 from snowfall.training.mmi_graph import get_phone_symbols
+
 
 def nbest_decoding(lats: k2.Fsa, num_paths: int):
     '''
@@ -292,7 +291,6 @@ def decode_one_batch(batch: Dict[str, Any],
 def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
            HLG: Fsa, symbols: SymbolTable,
            num_paths: int, G: k2.Fsa, use_whole_lattice: bool, output_beam_size: float):
-    tot_num_cuts = len(dataloader.dataset.cuts)
     num_cuts = 0
     results = defaultdict(list)
     # results is a dict whose keys and values are:
@@ -300,6 +298,12 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
     #         If no rescoring is used, the key is the literal string: no_rescore
     #
     #  - value: It is a list of tuples (ref_words, hyp_words)
+
+    num_batches = None
+    try:
+        num_batches = len(dataloader)
+    except AttributeError:
+        pass
 
     for batch_idx, batch in enumerate(dataloader):
         texts = batch['supervisions']['text']
@@ -324,10 +328,8 @@ def decode(dataloader: torch.utils.data.DataLoader, model: AcousticModel,
             results[lm_scale].extend(this_batch)
 
         if batch_idx % 10 == 0:
-            logging.info(
-                'batch {}, cuts processed until now is {}/{} ({:.6f}%)'.format(
-                    batch_idx, num_cuts, tot_num_cuts,
-                    float(num_cuts) / tot_num_cuts * 100))
+            batch_str = f"{batch_idx}" if num_batches is None else f"{batch_idx}/{num_batches}"
+            logging.info(f"batch {batch_str}, number of cuts processed until now is {num_cuts}")
 
         num_cuts += len(texts)
 


### PR DESCRIPTION
This PR removes any mentions of arrow/pyarrow and uses lazy JSONL loading for the manifests. It also adjusts the arguments to K2SpeechRecognitionDataset. As a bonus, there's a torchscript conversion in GigaSpeech decoding which I find handy. I verified that I'm able to start and run the GigaSpeech L training with both Lhotse and Snowfall PRs. I also adjusted the dataloading stuff for LibriSpeech/Aishell in the same way, but haven't run them.

Sorry for the reformatting of asr_datamodule.py, hopefully the diff is not too messed up.

The corresponding Lhotse PR is https://github.com/lhotse-speech/lhotse/pull/345. These two PRs should be merged together; I'll wait for either @danpovey or @csukuangfj to ack before merging both.

